### PR TITLE
Redo mock catalog and wrappers

### DIFF
--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -15,6 +15,36 @@ from astropy.coordinates import Angle
 # and for generating parameter files from uvfits files
 
 
+def write_uvfits(uv_obj, param_dict):
+    """
+        Parse output file information from parameters and write uvfits to file.
+    """
+    params = params['filing']
+    if 'outfile_name' not in params or params['outfile_name'] == '':
+        outfile_prefix = ""
+        outfile_suffix = "_results"
+        if 'outfile_prefix' in params:
+            outfile_prefix = params['outfile_prefix'] + "_"
+        if 'outfile_suffix' in params:
+            outfile_suffix = "_" + params['outfile_suffix']
+        outfile_name = os.path.join(params['outdir'], outfile_prefix
+                                    + os.path.basename(args['paramsfile'])[:-5]
+                                    + outfile_suffix)  # Strip .yaml extention
+    else:
+        outfile_name = params['outfile_name']
+    
+    outfile_name = outfile_name + ".uvfits"
+    
+    if 'clobber' not in params:
+        outfile_name = check_file_exists_and_increment(outfile_name)
+
+    if not os.path.exists(params['outdir']):
+        os.makedirs(params['outdir'])
+
+    uv_obj.write_uvfits(outfile_name, force_phase=True, spoof_nonessential=True)
+
+
+
 def strip_extension(filepath):
     if '.' not in filepath:
         return filepath, ''
@@ -25,7 +55,7 @@ def strip_extension(filepath):
 def check_file_exists_and_increment(filepath):
     """
         Given filepath (path + filename), check if it exists. If so, add a _1
-        at the end. etc.
+        at the end, if that exists add a _2, and so on.
     """
     if os.path.exists(filepath):
         filepath, ext = strip_extension(filepath)

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -19,30 +19,28 @@ def write_uvfits(uv_obj, param_dict):
     """
         Parse output file information from parameters and write uvfits to file.
     """
-    params = params['filing']
-    if 'outfile_name' not in params or params['outfile_name'] == '':
+    param_dict = param_dict['filing']
+    if 'outfile_name' not in param_dict or param_dict['outfile_name'] == '':
         outfile_prefix = ""
         outfile_suffix = "_results"
-        if 'outfile_prefix' in params:
-            outfile_prefix = params['outfile_prefix'] + "_"
-        if 'outfile_suffix' in params:
-            outfile_suffix = "_" + params['outfile_suffix']
-        outfile_name = os.path.join(params['outdir'], outfile_prefix
-                                    + os.path.basename(args['paramsfile'])[:-5]
+        if 'outfile_prefix' in param_dict:
+            outfile_prefix = param_dict['outfile_prefix'] + "_"
+        if 'outfile_suffix' in param_dict:
+            outfile_suffix = "_" + param_dict['outfile_suffix']
+        outfile_name = os.path.join(param_dict['outdir'], outfile_prefix
                                     + outfile_suffix)  # Strip .yaml extention
     else:
-        outfile_name = params['outfile_name']
-    
+        outfile_name = param_dict['outfile_name']
+
     outfile_name = outfile_name + ".uvfits"
-    
-    if 'clobber' not in params:
+
+    if 'clobber' not in param_dict:
         outfile_name = check_file_exists_and_increment(outfile_name)
 
-    if not os.path.exists(params['outdir']):
-        os.makedirs(params['outdir'])
+    if not os.path.exists(param_dict['outdir']):
+        os.makedirs(param_dict['outdir'])
 
     uv_obj.write_uvfits(outfile_name, force_phase=True, spoof_nonessential=True)
-
 
 
 def strip_extension(filepath):

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -80,6 +80,27 @@ def parse_layout_csv(layout_csv):
                          dtype=dt.dtype)
 
 
+def read_gleam_catalog(gleam_votable):
+    """
+    Creates a list of pyuvsim source objects from the GLEAM votable catalog.
+    Despite the semi-standard votable format, there are enough differences that every catalog probably
+    needs its own function.
+    List of tested catalogs: GLEAM EGC catalog, version 2
+    """
+
+    table = parse_single_table(gleam_votable)
+    data = table.array
+
+    sourcelist = []
+    for entry in data:
+        source = Source(entry['GLEAM'], Angle(entry['RAJ2000'], unit=units.deg),
+                        Angle(entry['DEJ2000'], unit=units.deg),
+                        freq=(200e6 * units.Hz),
+                        stokes=np.array([entry['Fintwide'], 0., 0., 0.]))
+        sourcelist.append(source)
+    return sourcelist
+
+
 def point_sources_from_params(catalog_csv):
     """
         Read in a text file of sources.

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -11,6 +11,7 @@ from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 import pyuvsim
 import astropy.units as units
 from astropy.coordinates import Angle
+from astropy.io.votable import parse_single_table
 # Utilities for setting up simulations for parameter files,
 # and for generating parameter files from uvfits files
 
@@ -93,7 +94,7 @@ def read_gleam_catalog(gleam_votable):
 
     sourcelist = []
     for entry in data:
-        source = Source(entry['GLEAM'], Angle(entry['RAJ2000'], unit=units.deg),
+        source = pyuvsim.Source(entry['GLEAM'], Angle(entry['RAJ2000'], unit=units.deg),
                         Angle(entry['DEJ2000'], unit=units.deg),
                         freq=(200e6 * units.Hz),
                         stokes=np.array([entry['Fintwide'], 0., 0., 0.]))

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -326,7 +326,8 @@ def initialize_uvdata_from_params(obs_params):
     param_dict['integration_time'] = time_params['integration_time']
     param_dict['time_array'] = time_arr
     param_dict['Ntimes'] = time_params['Ntimes']
-
+    param_dict['Nspws'] = 1
+    param_dict['Npols'] = 4
     # Now make a UVData object with these settings built in.
     # The syntax below allows for other valid uvdata keywords to be passed
     #  without explicitly setting them here.

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -95,9 +95,9 @@ def read_gleam_catalog(gleam_votable):
     sourcelist = []
     for entry in data:
         source = pyuvsim.Source(entry['GLEAM'], Angle(entry['RAJ2000'], unit=units.deg),
-                        Angle(entry['DEJ2000'], unit=units.deg),
-                        freq=(200e6 * units.Hz),
-                        stokes=np.array([entry['Fintwide'], 0., 0., 0.]))
+                                Angle(entry['DEJ2000'], unit=units.deg),
+                                freq=(200e6 * units.Hz),
+                                stokes=np.array([entry['Fintwide'], 0., 0., 0.]))
         sourcelist.append(source)
     return sourcelist
 

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -9,7 +9,6 @@ from astropy.time import Time
 from astropy.coordinates import Angle, SkyCoord, EarthLocation, AltAz
 from astropy import units
 from pyuvdata import UVBeam, UVData
-import pyuvdata.utils as uvutils
 from pyuvdata.data import DATA_PATH
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 import pyuvsim
@@ -38,8 +37,8 @@ def test_run_uvsim():
                        model_version='1.0')
 
     beam_list = [beam]
-
-    uv_out = pyuvsim.run_uvsim(hera_uv, beam_list, catalog=None, Nsrcs=3,
+    mock_keywords = {"Nsrcs" : 3}
+    uv_out = pyuvsim.run_uvsim(hera_uv, beam_list, catalog=None, mock_keywords=mock_keywords,
                                uvdata_file=EW_uvfits_file)
     if rank == 0:
         nt.assert_true(np.allclose(uv_out.data_array, hera_uv.data_array, atol=5e-3))

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -163,6 +163,6 @@ def test_point_catalog_reader():
 
 def test_read_gleam():
 
-    sourcelist = simsetup.read_gleam_catalog(GLEAM_vot)
+    sourcelist = pyuvsim.simsetup.read_gleam_catalog(GLEAM_vot)
 
     nt.assert_equal(len(sourcelist), 50)

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -20,6 +20,7 @@ herabeam_default = os.path.join(SIM_DATA_PATH, 'HERA_NicCST.uvbeam')
 param_filenames = [os.path.join(SIM_DATA_PATH, 'test_config', 'param_10time_10chan_{}.yaml'.format(x)) for x in range(4)]   # Five different test configs
 longbl_uvfits_file = os.path.join(SIM_DATA_PATH, '5km_triangle_1time_1chan.uvfits')
 triangle_uvfits_file = os.path.join(SIM_DATA_PATH, '28m_triangle_10time_10chan.uvfits')
+GLEAM_vot = os.path.join(SIM_DATA_PATH, 'gleam_50srcs.vot')
 
 
 def compare_dictionaries(dic1, dic2):
@@ -158,3 +159,10 @@ def test_point_catalog_reader():
         nt.assert_true(src.dec.deg in catalog_table['dec_j2000'])
         nt.assert_true(src.stokes[0] in catalog_table['flux_density_I'])
         nt.assert_true(src.freq.to("Hz").value in catalog_table['frequency'])
+
+
+def test_read_gleam():
+
+    sourcelist = simsetup.read_gleam_catalog(GLEAM_vot)
+
+    nt.assert_equal(len(sourcelist), 50)

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -796,27 +796,6 @@ def test_gather():
     nt.assert_true(np.allclose(uv_out.data_array, hera_uv.data_array, atol=5e-3))
 
 
-def test_run_serial_uvsim():
-    hera_uv = UVData()
-    hera_uv.read_uvfits(EW_uvfits_file)
-
-    beam = UVBeam()
-    beam.read_cst_beam(beam_files, beam_type='efield', frequency=[100e6, 123e6],
-                       telescope_name='HERA',
-                       feed_name='PAPER', feed_version='0.1', feed_pol=['x'],
-                       model_name='E-field pattern - Rigging height 4.9m',
-                       model_version='1.0')
-    beam_list = [beam]
-
-    uv_out = pyuvsim.run_serial_uvsim(hera_uv, beam_list, catalog=None, Nsrcs=1,
-                                      uvdata_file=EW_uvfits_file)
-
-    print np.round(uv_out.data_array)
-    print hera_uv.data_array
-
-    nt.assert_true(np.allclose(uv_out.data_array, hera_uv.data_array, atol=5e-3))
-
-
 def test_sources_equal():
     time = Time('2018-03-01 00:00:00', scale='utc')
     src1 = create_zenith_source(time, 'src')

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -399,7 +399,7 @@ def test_tophat_beam():
     time = Time('2018-03-01 00:00:00', scale='utc')
     array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',
                                    height=1073.)
-    source_list = pyuvsim.create_mock_catalog(time, 'hera_text', array_location=array_location)
+    source_list, mock_keywords = pyuvsim.create_mock_catalog(time, 'hera_text', array_location=array_location)
 
     nsrcs = len(source_list)
     az_vals = []
@@ -438,7 +438,7 @@ def test_gaussian_beam():
     time = Time('2018-03-01 00:00:00', scale='utc')
     array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',
                                    height=1073.)
-    source_list = pyuvsim.create_mock_catalog(time, 'hera_text', array_location=array_location)
+    source_list, mock_keywords = pyuvsim.create_mock_catalog(time, 'hera_text', array_location=array_location)
 
     nsrcs = len(source_list)
     az_vals = []
@@ -651,7 +651,7 @@ def test_yaml_to_tasks():
     HERA_location = EarthLocation(lat='-30d43m17.5s',
                                   lon='21d25m41.9s',
                                   height=1073.)
-    catalog = pyuvsim.create_mock_catalog(time, arrangement='zenith',
+    catalog, mock_keywords = pyuvsim.create_mock_catalog(time, arrangement='zenith',
                                           Nsrcs=10, array_location=HERA_location)
     print("Size of catalog:", sys.getsizeof(catalog), " bytes with ",
           len(catalog), "entries")
@@ -815,7 +815,7 @@ def test_mock_catalog():
     time = Time(hera_uv.time_array[0], scale='utc', format='jd')
 
     test_source = create_offzenith_source(time, 'src0', az=src_az, alt=src_alt)
-    cat = pyuvsim.create_mock_catalog(time, arrangement='off-zenith', zen_ang=src_za.deg)
+    cat, mock_keywords = pyuvsim.create_mock_catalog(time, arrangement='off-zenith', zen_ang=src_za.deg)
     cat_source = cat[0]
     for k in cat_source.__dict__:
         print 'Cat: ', k, cat_source.__dict__[k]
@@ -850,7 +850,7 @@ def test_gaussbeam_values():
 
     time = Time(hera_uv.time_array[0], scale='utc', format='jd')
 
-    catalog = pyuvsim.create_mock_catalog(time=time, arrangement='long-line', Nsrcs=41,
+    catalog, mock_keywords = pyuvsim.create_mock_catalog(time=time, arrangement='long-line', Nsrcs=41,
                                           max_za=10., array_location=array_location)
 
     beam = pyuvsim.AnalyticBeam('gaussian', sigma=sigma)

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -26,7 +26,6 @@ hera_miriad_file = os.path.join(DATA_PATH, 'hera_testfile')
 EW_uvfits_file = os.path.join(SIM_DATA_PATH, '28mEWbl_1time_1chan.uvfits')
 triangle_uvfits_file = os.path.join(SIM_DATA_PATH, '28m_triangle_10time_10chan.uvfits')
 longbl_uvfits_file = os.path.join(SIM_DATA_PATH, '5km_triangle_1time_1chan.uvfits')
-GLEAM_vot = os.path.join(SIM_DATA_PATH, 'gleam_50srcs.vot')
 longbl_yaml_file = os.path.join(SIM_DATA_PATH, '5km_triangle_1time_1chan.yaml')
 laptop_size_sim = os.path.join(SIM_DATA_PATH, 'laptop_size_sim.yaml')
 
@@ -652,7 +651,7 @@ def test_yaml_to_tasks():
                                   lon='21d25m41.9s',
                                   height=1073.)
     catalog, mock_keywords = pyuvsim.create_mock_catalog(time, arrangement='zenith',
-                                          Nsrcs=10, array_location=HERA_location)
+                                                         Nsrcs=10, array_location=HERA_location)
     print("Size of catalog:", sys.getsizeof(catalog), " bytes with ",
           len(catalog), "entries")
     uvtask_list = pyuvsim.uvdata_to_task_list(input_uv, catalog, beam_list)
@@ -825,13 +824,6 @@ def test_mock_catalog():
     nt.assert_equal(cat_source, test_source)
 
 
-def test_read_gleam():
-
-    sourcelist = pyuvsim.read_gleam_catalog(GLEAM_vot)
-
-    nt.assert_equal(len(sourcelist), 50)
-
-
 def test_gaussbeam_values():
     """
         Make the long-line point sources up to 10 degrees from zenith.
@@ -851,7 +843,7 @@ def test_gaussbeam_values():
     time = Time(hera_uv.time_array[0], scale='utc', format='jd')
 
     catalog, mock_keywords = pyuvsim.create_mock_catalog(time=time, arrangement='long-line', Nsrcs=41,
-                                          max_za=10., array_location=array_location)
+                                                         max_za=10., array_location=array_location)
 
     beam = pyuvsim.AnalyticBeam('gaussian', sigma=sigma)
     array = pyuvsim.Telescope('telescope_name', array_location, [beam])

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -958,7 +958,7 @@ def run_uvsim(input_uv, beam_list, beam_dict=None, catalog=None,
 
             mock_keyvals = [str(key) + str(val) for key, val in mock_keywords.iteritems()]
             source_list_name = 'mock_' + "_".join(mock_keyvals)
-        elif isinstance(catalog_file, str)
+        elif isinstance(catalog_file, str):
             source_list_name = catalog_file
             if catalog_file.endswith("txt"):
                 catalog = simsetup.point_sources_from_params(catalog_file)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -822,6 +822,9 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
 
     """
 
+    if isinstance(time, str):
+        time = Time(time, scale, 'utc', format='jd')
+
     if array_location is None:
         array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',
                                        height=1073.)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -17,6 +17,7 @@ from mpi4py import MPI
 from astropy.io.votable import parse_single_table
 import __builtin__
 from . import version as simversion
+from sys import stdout
 
 try:
     import progressbar
@@ -1001,17 +1002,18 @@ def run_uvsim(input_uv, beam_list, catalog=None, Nsrcs=None,
         uvtask_list = np.array_split(uvtask_list, Npus)
         uvtask_list = [list(tl) for tl in uvtask_list]
 
-        print("Sending Tasks To Processing Units")
+        print("Sending Tasks To Processing Units"); stdout.flush()
     # Scatter the task list among all available PUs
     local_task_list = comm.scatter(uvtask_list, root=0)
     if rank == 0:
-        print("Tasks Received. Begin Calculations.")
+        print("Tasks Received. Begin Calculations."); stdout.flush()
     summed_task_dict = {}
 
     if rank == 0:
         if progsteps or progbar:
             count = 0
             tot = len(local_task_list)
+            print("Local tasks: ", tot); stdout.flush()
             if progbar:
                 pbar = progressbar.ProgressBar(maxval=tot).start()
             else:

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -823,7 +823,7 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
     """
 
     if not isinstance(time, Time):
-        time = Time(time, scale, 'utc', format='jd')
+        time = Time(time, scale='utc', format='jd')
 
     if array_location is None:
         array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',
@@ -924,11 +924,29 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
 
 
 @profile
-def run_uvsim(input_uv, beam_list, catalog=None,
+def run_uvsim(input_uv, beam_list, beam_dict=None, catalog=None,
               mock_keywords=None,
               uvdata_file=None, obs_param_file=None,
               telescope_config_file=None, antenna_location_file=None):
-    """Run uvsim."""
+    """
+    Run uvsim
+
+    Arguments:
+        input_uv: An input UVData object, containing baseline/time/frequency information.
+        beam_list: A list of UVBeam and/or AnalyticBeam objects
+
+    Keywords:
+        beam_dict: Dictionary of {antenna_name : beam_ID}, where beam_id is an index in 
+                   the beam_list. This assigns beams to antennas.
+                   Default: All antennas get the 0th beam in the beam_list.
+        catalog: Catalog file name.
+                   Default: Create a mock catalog
+        mock_keywords: Settings for a mock catalog (see keywords of create_mock_catalog)
+        uvdata_file: Name of input UVData file if running from a file.
+        obs_param_file: Parameter filename if running from config files.
+        telescope_config_file: Telescope configuration file if running from config files.
+        antenna_location_file: antenna_location file if running from config files.
+    """
     if not isinstance(input_uv, UVData):
         raise TypeError("input_uv must be UVData object")
 
@@ -943,25 +961,30 @@ def run_uvsim(input_uv, beam_list, catalog=None,
             # time, arrangement, array_location, save, Nsrcs, max_za
 
             if mock_keywords is None:
+                mock_keywords = {}
+
+            if not 'array_location' in mock_keywords:
                 array_loc = EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')
-                mock_keywords = {'array_location': array_loc}          # Will lead to default behavior
+                mock_keywords['array_location'] = array_loc
+            if not 'time' in mock_keywords:
+                mock_keywords['time'] = input_uv.time_array[0]
 
             if not "array_location" in mock_keywords:
                 print("Warning: No array_location given for mock catalog. Defaulting to HERA site")
             if not 'time' in mock_keywords:
                 print("Warning: No julian date given for mock catalog. Defaulting to first of input_UV object")
 
-            time = mock_keywords.pop('time', input_uv.time_array[0])
+            time = mock_keywords.pop('time')
 
             catalog, mock_keywords = create_mock_catalog(time, **mock_keywords)
 
-            mock_keyvals = [str(key) + str(val) for key, val in mock_keywords]
+            mock_keyvals = [str(key) + str(val) for key, val in mock_keywords.iteritems()]
             source_list_name = 'mock_' + "_".join(mock_keyvals)
         else:
             source_list_name = catalog
 
         print('Nsrcs:', catalog.size)
-        uvtask_list = uvdata_to_task_list(input_uv, catalog, beam_list)
+        uvtask_list = uvdata_to_task_list(input_uv, catalog, beam_list, beam_dict=beam_dict)
 
         if 'obs_param_file' in input_uv.extra_keywords:
             obs_param_file = input_uv.extra_keywords['obs_param_file']

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -923,50 +923,6 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
     return catalog, mock_keywords
 
 
-def run_serial_uvsim(input_uv, beam_list, catalog=None, Nsrcs=None,
-                     mock_arrangement='zenith', max_za=-1, save_catalog=False,
-                     uvdata_file=None, obs_param_file=None,
-                     telescope_config_file=None, antenna_location_file=None):
-    """Run uvsim."""
-
-    if not isinstance(input_uv, UVData):
-        raise TypeError("input_uv must be UVData object")
-
-    time = Time(input_uv.time_array[0], scale='utc', format='jd')
-    if catalog is None:
-        array_loc = EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')
-        catalog = create_mock_catalog(time, arrangement=mock_arrangement,
-                                      array_location=array_loc,
-                                      save=save_catalog, Nsrcs=Nsrcs, max_za=max_za)
-        source_list_name = mock_arrangement + '_N=' + str(Nsrcs) + '_maxza=' + str(max_za)
-    else:
-        source_list_name = catalog
-
-    uvtask_list = uvdata_to_task_list(input_uv, catalog, beam_list)
-
-    if 'obs_param_file' in input_uv.extra_keywords:
-        obs_param_file = input_uv.extra_keywords['obs_param_file']
-        telescope_config_file = input_uv.extra_keywords['telescope_config_file']
-        antenna_location_file = input_uv.extra_keywords['antenna_location_file']
-        uvdata_file_pass = None
-    else:
-        uvdata_file_pass = uvdata_file
-
-    uvdata_out = initialize_uvdata(uvtask_list, source_list_name,
-                                   uvdata_file=uvdata_file_pass,
-                                   obs_param_file=obs_param_file,
-                                   telescope_config_file=telescope_config_file,
-                                   antenna_location_file=antenna_location_file)
-
-    for task in uvtask_list:
-        engine = UVEngine(task)
-        task.visibility_vector = engine.make_visibility()
-
-    uvdata_out = serial_gather(uvtask_list, uvdata_out)
-
-    return uvdata_out
-
-
 @profile
 def run_uvsim(input_uv, beam_list, catalog=None,
               mock_keywords=None,

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -14,7 +14,6 @@ import os
 import utils
 from itertools import izip
 from mpi4py import MPI
-from astropy.io.votable import parse_single_table
 import __builtin__
 from . import version as simversion
 from sys import stdout

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -936,7 +936,7 @@ def run_uvsim(input_uv, beam_list, beam_dict=None, catalog=None,
         beam_list: A list of UVBeam and/or AnalyticBeam objects
 
     Keywords:
-        beam_dict: Dictionary of {antenna_name : beam_ID}, where beam_id is an index in 
+        beam_dict: Dictionary of {antenna_name : beam_ID}, where beam_id is an index in
                    the beam_list. This assigns beams to antennas.
                    Default: All antennas get the 0th beam in the beam_list.
         catalog: Catalog file name.
@@ -963,15 +963,15 @@ def run_uvsim(input_uv, beam_list, beam_dict=None, catalog=None,
             if mock_keywords is None:
                 mock_keywords = {}
 
-            if not 'array_location' in mock_keywords:
+            if 'array_location' not in mock_keywords:
                 array_loc = EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')
                 mock_keywords['array_location'] = array_loc
-            if not 'time' in mock_keywords:
+            if 'time' not in mock_keywords:
                 mock_keywords['time'] = input_uv.time_array[0]
 
-            if not "array_location" in mock_keywords:
+            if "array_location" not in mock_keywords:
                 print("Warning: No array_location given for mock catalog. Defaulting to HERA site")
-            if not 'time' in mock_keywords:
+            if 'time' not in mock_keywords:
                 print("Warning: No julian date given for mock catalog. Defaulting to first of input_UV object")
 
             time = mock_keywords.pop('time')

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -805,7 +805,7 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
     """
         Create mock catalog with test sources at zenith.
 
-        arrangment = Choose test point source pattern (default = 1 source at zenith)
+        arrangement = Choose test point source pattern (default = 1 source at zenith)
         Keywords:
             Nsrcs = Number of sources to put at zenith
             array_location = EarthLocation object.
@@ -822,7 +822,7 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
 
     """
 
-    if isinstance(time, str):
+    if not isinstance(time, Time):
         time = Time(time, scale, 'utc', format='jd')
 
     if array_location is None:
@@ -833,9 +833,13 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
     if arrangement not in ['off-zenith', 'zenith', 'cross', 'triangle', 'long-line', 'hera_text']:
         raise KeyError("Invalid mock catalog arrangement: " + str(arrangement))
 
+    mock_keywords = {'time': time.jd, 'arrangement': arrangement,
+                     'array_location': repr((array_location.lat, array_location.lon, array_location.alt))}
+
     if arrangement == 'off-zenith':
         if zen_ang is None:
             zen_ang = 5.0  # Degrees
+        mock_keywords['zen_ang'] = zen_ang
         Nsrcs = 1
         alts = [90. - zen_ang]
         azs = [90.]   # 0 = North pole, 90. = East pole
@@ -845,6 +849,7 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
         Nsrcs = 3
         if zen_ang is None:
             zen_ang = 3.0
+        mock_keywords['zen_ang'] = zen_ang
         alts = [90. - zen_ang, 90. - zen_ang, 90. - zen_ang]
         azs = [0., 120., 240.]
         fluxes = [1.0, 1.0, 1.0]
@@ -858,6 +863,7 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
     if arrangement == 'zenith':
         if Nsrcs is None:
             Nsrcs = 1
+        mock_keywords['Nsrcs'] = Nsrcs
         alts = np.ones(Nsrcs) * 90.
         azs = np.zeros(Nsrcs, dtype=float)
         fluxes = np.ones(Nsrcs) * 1 / Nsrcs
@@ -868,6 +874,8 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
             Nsrcs = 10
         if max_za < 0:
             max_za = 85
+        mock_keywords['Nsrcs'] = Nsrcs
+        mock_keywords['zen_ang'] = zen_ang
         fluxes = np.ones(Nsrcs, dtype=float)
         zas = np.linspace(-max_za, max_za, Nsrcs)
         alts = 90. - zas
@@ -912,7 +920,7 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
         np.savez('mock_catalog_' + arrangement, ra=ra.rad, dec=dec.rad, alts=alts, azs=azs, fluxes=fluxes)
 
     catalog = np.array(catalog)
-    return catalog
+    return catalog, mock_keywords
 
 
 def run_serial_uvsim(input_uv, beam_list, catalog=None, Nsrcs=None,
@@ -960,8 +968,8 @@ def run_serial_uvsim(input_uv, beam_list, catalog=None, Nsrcs=None,
 
 
 @profile
-def run_uvsim(input_uv, beam_list, catalog=None, Nsrcs=None,
-              mock_arrangement='zenith', max_za=-1, save_catalog=False,
+def run_uvsim(input_uv, beam_list, catalog=None,
+              mock_keywords=None,
               uvdata_file=None, obs_param_file=None,
               telescope_config_file=None, antenna_location_file=None):
     """Run uvsim."""
@@ -974,12 +982,25 @@ def run_uvsim(input_uv, beam_list, catalog=None, Nsrcs=None,
     if rank == 0:
         print('Nblts:', input_uv.Nblts)
         print('Nfreqs:', input_uv.Nfreqs)
-        time = Time(input_uv.time_array[0], scale='utc', format='jd')
-        if catalog is None:
-            array_loc = EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')
-            catalog = create_mock_catalog(time, arrangement=mock_arrangement, array_location=array_loc,
-                                          save=save_catalog, Nsrcs=Nsrcs, max_za=max_za)
-            source_list_name = mock_arrangement + '_N=' + str(Nsrcs) + '_maxza=' + str(max_za)
+
+        if catalog is None or catalog == 'mock':
+            # time, arrangement, array_location, save, Nsrcs, max_za
+
+            if mock_keywords is None:
+                array_loc = EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')
+                mock_keywords = {'array_location': array_loc}          # Will lead to default behavior
+
+            if not "array_location" in mock_keywords:
+                print("Warning: No array_location given for mock catalog. Defaulting to HERA site")
+            if not 'time' in mock_keywords:
+                print("Warning: No julian date given for mock catalog. Defaulting to first of input_UV object")
+
+            time = mock_keywords.pop('time', input_uv.time_array[0])
+
+            catalog, mock_keywords = create_mock_catalog(time, **mock_keywords)
+
+            mock_keyvals = [str(key) + str(val) for key, val in mock_keywords]
+            source_list_name = 'mock_' + "_".join(mock_keyvals)
         else:
             source_list_name = catalog
 

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -834,7 +834,7 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
         raise KeyError("Invalid mock catalog arrangement: " + str(arrangement))
 
     mock_keywords = {'time': time.jd, 'arrangement': arrangement,
-                     'array_location': repr((array_location.lat, array_location.lon, array_location.alt))}
+                     'array_location': repr((array_location.lat.deg, array_location.lon.deg, array_location.height.value))}
 
     if arrangement == 'off-zenith':
         if zen_ang is None:

--- a/scripts/run_param_pyuvsim.py
+++ b/scripts/run_param_pyuvsim.py
@@ -96,10 +96,9 @@ if rank == 0:
             mock_keywords = None
             catalog = None   # Will default to a single point source at zenith
         if source_params['catalog'] == 'mock':
- #           time, arrangement='zenith', array_location=None, Nsrcs=None, zen_ang=None, save=False, max_za=-1.0
-            mock_keywords = { 'time' : input_uv.time_array[0], 'arrangement' : source_params['mock_arrangement'],
-                              'array_location' : EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')}
-            extra_mock_kwds = ['Nsrcs', 'zen_ang', 'save', 'max_za']
+            mock_keywords = {'time': input_uv.time_array[0], 'arrangement': source_params['mock_arrangement'],
+                              'array_location': EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')}
+            extra_mock_kwds = ['time', 'Nsrcs', 'zen_ang', 'save', 'max_za']
             for k in extra_mock_kwds:
                 if k in source_params.keys():
                     mock_keywords[k] = source_params[k]
@@ -112,7 +111,7 @@ if rank == 0:
 
     elif source_params['catalog'].endswith('txt'):
             catalog = np.array(simsetup.point_sources_from_params(source_params['catalog']))
-            catalog =  source_params['catalog']
+            catalog = source_params['catalog']
         else:
             catalog = None
 

--- a/scripts/run_param_pyuvsim.py
+++ b/scripts/run_param_pyuvsim.py
@@ -67,34 +67,8 @@ if rank == 0:
         input_uv, beam_list, beam_dict, beam_ids = simsetup.initialize_uvdata_from_params(args['paramsfile'])
         print("Nfreqs: ", input_uv.Nfreqs)
         print("Ntimes: ", input_uv.Ntimes)
-        beam = beam_list[0]
-        file_params = params['filing']
-        params.update(file_params)
-        del params['filing']
-        if 'outfile_name' not in params or params['outfile_name'] == '':
-            outfile_prefix = ""
-            outfile_suffix = "_results"
-            if 'outfile_prefix' in params:
-                outfile_prefix = params['outfile_prefix'] + "_"
-            if 'outfile_suffix' in params:
-                outfile_suffix = "_" + params['outfile_suffix']
-            outfile_name = os.path.join(params['outdir'], outfile_prefix
-                                        + os.path.basename(args['paramsfile'])[:-5]
-                                        + outfile_suffix)  # Strip .yaml extention
-        else:
-            outfile_name = params['outfile_name']
-
-        outfile_name = outfile_name + ".uvfits"
-
-        if 'clobber' not in params:
-            outfile_name = simsetup.check_file_exists_and_increment(outfile_name)
-
-        try:
-            source_params = params['sources']
-        except KeyError:
-            print("Warning: No catalog information provided!")
-            mock_keywords = None
-            catalog = None   # Will default to a single point source at zenith
+        beam = beam_list[0]  ## TODO Replace this!
+        source_params = params['sources']
         if source_params['catalog'] == 'mock':
             mock_keywords = {'time': input_uv.time_array[0], 'arrangement': source_params['mock_arrangement'],
                               'array_location': EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')}
@@ -120,6 +94,4 @@ beam_list = [beam]
 uvdata_out = pyuvsim.uvsim.run_uvsim(input_uv, beam_list=beam_list, catalog=catalog, mock_keywords=mock_keywords)
 
 if rank == 0:
-    if not os.path.exists(params['outdir']):
-        os.makedirs(params['outdir'])
-    uvdata_out.write_uvfits(outfile_name, force_phase=True, spoof_nonessential=True)
+    simsetup.write_uvfits(uvdata_out, params)

--- a/scripts/run_param_pyuvsim.py
+++ b/scripts/run_param_pyuvsim.py
@@ -13,6 +13,7 @@ from pyuvdata import UVBeam, UVData
 from pyuvdata.data import DATA_PATH
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 from pyuvsim import simsetup
+from astropy.coordinates import EarthLocation
 
 
 comm = MPI.COMM_WORLD
@@ -71,7 +72,7 @@ if rank == 0:
         source_params = params['sources']
         if source_params['catalog'] == 'mock':
             mock_keywords = {'time': input_uv.time_array[0], 'arrangement': source_params['mock_arrangement'],
-                              'array_location': EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')}
+                             'array_location': EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')}
             extra_mock_kwds = ['time', 'Nsrcs', 'zen_ang', 'save', 'max_za']
             for k in extra_mock_kwds:
                 if k in source_params.keys():

--- a/scripts/run_pyuvsim.py
+++ b/scripts/run_pyuvsim.py
@@ -53,15 +53,19 @@ for filename in args.file_in:
 
     beam = pyuvsim.AnalyticBeam('gaussian', sigma=0.0222)
     beam_list = [beam]
-    extra_keywords = {'obs_param_file': 'uvfits_file='+os.path.basename(filename),
+    extra_keywords = {'obs_param_file': 'uvfits_file=' + os.path.basename(filename),
                       'telescope_config_file': beam.type,
                       'antenna_location_file': os.path.basename(filename)}
     input_uv.extra_keywords = extra_keywords
+
+    mock_keywords = {}
+    mock_keywords['save'] = args.save_catalog
+    mock_keywords['max_za'] = args.save_catalog
+    mock_keywords['arrangement'] = args.mock_arrangement
+
     uvdata_out = pyuvsim.uvsim.run_uvsim(input_uv, beam_list=beam_list,
-                                         mock_arrangement=args.mock_arrangement,
-                                         max_za=args.max_za,
-                                         save_catalog=args.save_catalog,
-                                         Nsrcs=args.Nsrcs)
+                                         mock_keywords=mock_keywords)
+
     if rank == 0:
         outfile = os.path.join(args.outdir, 'sim_' + os.path.basename(filename))
         if not os.path.exists(args.outdir):


### PR DESCRIPTION
I didn't like that all of the keywords for "create_mock_catalog" had to be keywords for "run_pyuvsim" as well, so I've wrapped them up in a dictionary. The accepted keywords are still properly documented in the create_mock_catalog docstring (ie., no "kwargs"), but run_pyuvsim has keywords that are relevant to it now.

I've also deleted the "run_serial_uvsim" function. It's no longer used by anything except a single unit test (also deleted), which just checks that it runs. We have a unit test for "run_uvsim" already.

Lastly, the wrappers run_pyuvsim and run_param_pyuvsim have been updated to work with the new setup.

