### PR TITLE
DO NOT MERGE -- Local task generation

### DIFF
--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -19,30 +19,28 @@ def write_uvfits(uv_obj, param_dict):
     """
         Parse output file information from parameters and write uvfits to file.
     """
-    params = params['filing']
-    if 'outfile_name' not in params or params['outfile_name'] == '':
+    param_dict = param_dict['filing']
+    if 'outfile_name' not in param_dict or param_dict['outfile_name'] == '':
         outfile_prefix = ""
         outfile_suffix = "_results"
-        if 'outfile_prefix' in params:
-            outfile_prefix = params['outfile_prefix'] + "_"
-        if 'outfile_suffix' in params:
-            outfile_suffix = "_" + params['outfile_suffix']
-        outfile_name = os.path.join(params['outdir'], outfile_prefix
-                                    + os.path.basename(args['paramsfile'])[:-5]
+        if 'outfile_prefix' in param_dict:
+            outfile_prefix = param_dict['outfile_prefix'] + "_"
+        if 'outfile_suffix' in param_dict:
+            outfile_suffix = "_" + param_dict['outfile_suffix']
+        outfile_name = os.path.join(param_dict['outdir'], outfile_prefix
                                     + outfile_suffix)  # Strip .yaml extention
     else:
-        outfile_name = params['outfile_name']
-    
+        outfile_name = param_dict['outfile_name']
+
     outfile_name = outfile_name + ".uvfits"
-    
-    if 'clobber' not in params:
+
+    if 'clobber' not in param_dict:
         outfile_name = check_file_exists_and_increment(outfile_name)
 
-    if not os.path.exists(params['outdir']):
-        os.makedirs(params['outdir'])
+    if not os.path.exists(param_dict['outdir']):
+        os.makedirs(param_dict['outdir'])
 
     uv_obj.write_uvfits(outfile_name, force_phase=True, spoof_nonessential=True)
-
 
 
 def strip_extension(filepath):

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -326,7 +326,8 @@ def initialize_uvdata_from_params(obs_params):
     param_dict['integration_time'] = time_params['integration_time']
     param_dict['time_array'] = time_arr
     param_dict['Ntimes'] = time_params['Ntimes']
-
+    param_dict['Nspws'] = 1
+    param_dict['Npols'] = 4
     # Now make a UVData object with these settings built in.
     # The syntax below allows for other valid uvdata keywords to be passed
     #  without explicitly setting them here.

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -9,7 +9,6 @@ from astropy.time import Time
 from astropy.coordinates import Angle, SkyCoord, EarthLocation, AltAz
 from astropy import units
 from pyuvdata import UVBeam, UVData
-import pyuvdata.utils as uvutils
 from pyuvdata.data import DATA_PATH
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 import pyuvsim
@@ -38,8 +37,8 @@ def test_run_uvsim():
                        model_version='1.0')
 
     beam_list = [beam]
-
-    uv_out = pyuvsim.run_uvsim(hera_uv, beam_list, catalog=None, Nsrcs=3,
+    mock_keywords = {"Nsrcs" : 3}
+    uv_out = pyuvsim.run_uvsim(hera_uv, beam_list, catalog=None, mock_keywords=mock_keywords,
                                uvdata_file=EW_uvfits_file)
     if rank == 0:
         nt.assert_true(np.allclose(uv_out.data_array, hera_uv.data_array, atol=5e-3))

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -796,27 +796,6 @@ def test_gather():
     nt.assert_true(np.allclose(uv_out.data_array, hera_uv.data_array, atol=5e-3))
 
 
-def test_run_serial_uvsim():
-    hera_uv = UVData()
-    hera_uv.read_uvfits(EW_uvfits_file)
-
-    beam = UVBeam()
-    beam.read_cst_beam(beam_files, beam_type='efield', frequency=[100e6, 123e6],
-                       telescope_name='HERA',
-                       feed_name='PAPER', feed_version='0.1', feed_pol=['x'],
-                       model_name='E-field pattern - Rigging height 4.9m',
-                       model_version='1.0')
-    beam_list = [beam]
-
-    uv_out = pyuvsim.run_serial_uvsim(hera_uv, beam_list, catalog=None, Nsrcs=1,
-                                      uvdata_file=EW_uvfits_file)
-
-    print np.round(uv_out.data_array)
-    print hera_uv.data_array
-
-    nt.assert_true(np.allclose(uv_out.data_array, hera_uv.data_array, atol=5e-3))
-
-
 def test_sources_equal():
     time = Time('2018-03-01 00:00:00', scale='utc')
     src1 = create_zenith_source(time, 'src')

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -399,7 +399,7 @@ def test_tophat_beam():
     time = Time('2018-03-01 00:00:00', scale='utc')
     array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',
                                    height=1073.)
-    source_list = pyuvsim.create_mock_catalog(time, 'hera_text', array_location=array_location)
+    source_list, mock_keywords = pyuvsim.create_mock_catalog(time, 'hera_text', array_location=array_location)
 
     nsrcs = len(source_list)
     az_vals = []
@@ -438,7 +438,7 @@ def test_gaussian_beam():
     time = Time('2018-03-01 00:00:00', scale='utc')
     array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',
                                    height=1073.)
-    source_list = pyuvsim.create_mock_catalog(time, 'hera_text', array_location=array_location)
+    source_list, mock_keywords = pyuvsim.create_mock_catalog(time, 'hera_text', array_location=array_location)
 
     nsrcs = len(source_list)
     az_vals = []
@@ -651,7 +651,7 @@ def test_yaml_to_tasks():
     HERA_location = EarthLocation(lat='-30d43m17.5s',
                                   lon='21d25m41.9s',
                                   height=1073.)
-    catalog = pyuvsim.create_mock_catalog(time, arrangement='zenith',
+    catalog, mock_keywords = pyuvsim.create_mock_catalog(time, arrangement='zenith',
                                           Nsrcs=10, array_location=HERA_location)
     print("Size of catalog:", sys.getsizeof(catalog), " bytes with ",
           len(catalog), "entries")
@@ -815,7 +815,7 @@ def test_mock_catalog():
     time = Time(hera_uv.time_array[0], scale='utc', format='jd')
 
     test_source = create_offzenith_source(time, 'src0', az=src_az, alt=src_alt)
-    cat = pyuvsim.create_mock_catalog(time, arrangement='off-zenith', zen_ang=src_za.deg)
+    cat, mock_keywords = pyuvsim.create_mock_catalog(time, arrangement='off-zenith', zen_ang=src_za.deg)
     cat_source = cat[0]
     for k in cat_source.__dict__:
         print 'Cat: ', k, cat_source.__dict__[k]
@@ -850,7 +850,7 @@ def test_gaussbeam_values():
 
     time = Time(hera_uv.time_array[0], scale='utc', format='jd')
 
-    catalog = pyuvsim.create_mock_catalog(time=time, arrangement='long-line', Nsrcs=41,
+    catalog, mock_keywords = pyuvsim.create_mock_catalog(time=time, arrangement='long-line', Nsrcs=41,
                                           max_za=10., array_location=array_location)
 
     beam = pyuvsim.AnalyticBeam('gaussian', sigma=sigma)

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -640,6 +640,29 @@ def test_single_offzenith_source_miriad():
     nt.assert_true(np.allclose(visibility, vis_analytic, atol=5e-3))
 
 
+def test_task_sort():
+    hera_uv = UVData()
+    hera_uv.read_uvfits(triangle_uvfits_file)
+
+    time = Time(hera_uv.time_array[0], scale='utc', format='jd')
+    sources = np.array([create_zenith_source(time, 'zensrc')])
+
+    beam = UVBeam()
+    beam.read_cst_beam(beam_files, beam_type='efield', frequency=[150e6, 123e6],
+                       telescope_name='HERA',
+                       feed_name='PAPER', feed_version='0.1', feed_pol=['x'],
+                       model_name='E-field pattern - Rigging height 4.9m',
+                       model_version='1.0')
+
+    beam_list = [beam]
+
+    uvtask_list = pyuvsim.uvdata_to_task_list(hera_uv, sources, beam_list)
+    uvtask_list.sort()
+
+    for task in uvtask_list:
+        print task.time, task.freq, task.baseline.antenna1.number, task.baseline.antenna2.number, task.source.name
+
+
 @profile
 def test_yaml_to_tasks():
     #    params = yaml.safe_load(open(longbl_yaml_file))

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -833,7 +833,7 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
         raise KeyError("Invalid mock catalog arrangement: " + str(arrangement))
 
     mock_keywords = {'time': time.jd, 'arrangement': arrangement,
-                     'array_location': repr((array_location.lat, array_location.lon, array_location.alt))}
+                     'array_location': repr((array_location.lat.deg, array_location.lon.deg, array_location.height.value))}
 
     if arrangement == 'off-zenith':
         if zen_ang is None:

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -1155,6 +1155,7 @@ def run_uvsim(input_uv, beam_list, beam_dict=None, catalog=None,
 
     Ntasks = Nblts * Nfreqs * Nsrcs
 
+    input_uv = comm.bcast(input_uv, root=0)
     # From the rank, determine which tasks to run here.
     stride = Ntasks // Npus
     task_ids = np.arange(rank * stride, (rank + 1) * stride)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -821,6 +821,9 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
 
     """
 
+    if isinstance(time, str):
+        time = Time(time, scale, 'utc', format='jd')
+
     if array_location is None:
         array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',
                                        height=1073.)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -705,6 +705,10 @@ def init_uvdata_out(uv_in, source_list_name, uvdata_file=None,
     uv_obj.set_drift()
     uv_obj.vis_units = 'Jy'
     uv_obj.polarization_array = np.array([-5, -6, -7, -8])
+    uv_obj.instrument = uv_obj.telescope_name
+    uv_obj.set_lsts_from_time_array()
+    uv_obj.spw_array = np.array([0])
+    uv_obj.set_uvws_from_antenna_positions()
 
     # Clear existing data, if any
     uv_obj.data_array = np.zeros((uv_obj.Nblts, uv_obj.Nspws, uv_obj.Nfreqs, uv_obj.Npols), dtype=np.complex)
@@ -712,6 +716,7 @@ def init_uvdata_out(uv_in, source_list_name, uvdata_file=None,
     uv_obj.nsample_array = np.ones_like(uv_obj.data_array, dtype=float)
     uv_obj.history = history
 
+    uv_obj.extra_keywords = {}
     uv_obj.check()
 
     return uv_obj

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -935,7 +935,7 @@ def run_uvsim(input_uv, beam_list, beam_dict=None, catalog=None,
         beam_list: A list of UVBeam and/or AnalyticBeam objects
 
     Keywords:
-        beam_dict: Dictionary of {antenna_name : beam_ID}, where beam_id is an index in 
+        beam_dict: Dictionary of {antenna_name : beam_ID}, where beam_id is an index in
                    the beam_list. This assigns beams to antennas.
                    Default: All antennas get the 0th beam in the beam_list.
         catalog: Catalog file name.
@@ -962,15 +962,15 @@ def run_uvsim(input_uv, beam_list, beam_dict=None, catalog=None,
             if mock_keywords is None:
                 mock_keywords = {}
 
-            if not 'array_location' in mock_keywords:
+            if 'array_location' not in mock_keywords:
                 array_loc = EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')
                 mock_keywords['array_location'] = array_loc
-            if not 'time' in mock_keywords:
+            if 'time' not in mock_keywords:
                 mock_keywords['time'] = input_uv.time_array[0]
 
-            if not "array_location" in mock_keywords:
+            if "array_location" not in mock_keywords:
                 print("Warning: No array_location given for mock catalog. Defaulting to HERA site")
-            if not 'time' in mock_keywords:
+            if 'time' not in mock_keywords:
                 print("Warning: No julian date given for mock catalog. Defaulting to first of input_UV object")
 
             time = mock_keywords.pop('time')

--- a/scripts/run_param_pyuvsim.py
+++ b/scripts/run_param_pyuvsim.py
@@ -13,6 +13,7 @@ from pyuvdata import UVBeam, UVData
 from pyuvdata.data import DATA_PATH
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 from pyuvsim import simsetup
+from astropy.coordinates import EarthLocation
 
 
 comm = MPI.COMM_WORLD
@@ -78,7 +79,7 @@ if rank == 0:
         source_params = params['sources']
         if source_params['catalog'] == 'mock':
             mock_keywords = {'time': input_uv.time_array[0], 'arrangement': source_params['mock_arrangement'],
-                              'array_location': EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')}
+                             'array_location': EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')}
             extra_mock_kwds = ['time', 'Nsrcs', 'zen_ang', 'save', 'max_za']
             for k in extra_mock_kwds:
                 if k in source_params.keys():

--- a/scripts/run_param_pyuvsim.py
+++ b/scripts/run_param_pyuvsim.py
@@ -96,10 +96,9 @@ if rank == 0:
             mock_keywords = None
             catalog = None   # Will default to a single point source at zenith
         if source_params['catalog'] == 'mock':
- #           time, arrangement='zenith', array_location=None, Nsrcs=None, zen_ang=None, save=False, max_za=-1.0
-            mock_keywords = { 'time' : input_uv.time_array[0], 'arrangement' : source_params['mock_arrangement'],
-                              'array_location' : EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')}
-            extra_mock_kwds = ['Nsrcs', 'zen_ang', 'save', 'max_za']
+            mock_keywords = {'time': input_uv.time_array[0], 'arrangement': source_params['mock_arrangement'],
+                              'array_location': EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')}
+            extra_mock_kwds = ['time', 'Nsrcs', 'zen_ang', 'save', 'max_za']
             for k in extra_mock_kwds:
                 if k in source_params.keys():
                     mock_keywords[k] = source_params[k]
@@ -112,7 +111,7 @@ if rank == 0:
 
     elif source_params['catalog'].endswith('txt'):
             catalog = np.array(simsetup.point_sources_from_params(source_params['catalog']))
-            catalog =  source_params['catalog']
+            catalog = source_params['catalog']
         else:
             catalog = None
 

--- a/scripts/run_pyuvsim.py
+++ b/scripts/run_pyuvsim.py
@@ -53,6 +53,10 @@ for filename in args.file_in:
 
     beam = pyuvsim.AnalyticBeam('gaussian', sigma=0.0222)
     beam_list = [beam]
+    extra_keywords = {'obs_param_file': 'uvfits_file='+os.path.basename(filename),
+                      'telescope_config_file': beam.type,
+                      'antenna_location_file': os.path.basename(filename)}
+    input_uv.extra_keywords = extra_keywords
     uvdata_out = pyuvsim.uvsim.run_uvsim(input_uv, beam_list=beam_list,
                                          mock_arrangement=args.mock_arrangement,
                                          max_za=args.max_za,

--- a/scripts/run_pyuvsim.py
+++ b/scripts/run_pyuvsim.py
@@ -53,15 +53,19 @@ for filename in args.file_in:
 
     beam = pyuvsim.AnalyticBeam('gaussian', sigma=0.0222)
     beam_list = [beam]
-    extra_keywords = {'obs_param_file': 'uvfits_file='+os.path.basename(filename),
+    extra_keywords = {'obs_param_file': 'uvfits_file=' + os.path.basename(filename),
                       'telescope_config_file': beam.type,
                       'antenna_location_file': os.path.basename(filename)}
     input_uv.extra_keywords = extra_keywords
+
+    mock_keywords = {}
+    mock_keywords['save'] = args.save_catalog
+    mock_keywords['max_za'] = args.save_catalog
+    mock_keywords['arrangement'] = args.mock_arrangement
+
     uvdata_out = pyuvsim.uvsim.run_uvsim(input_uv, beam_list=beam_list,
-                                         mock_arrangement=args.mock_arrangement,
-                                         max_za=args.max_za,
-                                         save_catalog=args.save_catalog,
-                                         Nsrcs=args.Nsrcs)
+                                         mock_keywords=mock_keywords)
+
     if rank == 0:
         outfile = os.path.join(args.outdir, 'sim_' + os.path.basename(filename))
         if not os.path.exists(args.outdir):


### PR DESCRIPTION
This is my attempt so far to implement Danny's suggestion. The input_uv object gets broadcast to each rank and the following lines determine which tasks get generated:
https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/bcebb1407b6f60af7e53331a8410c2d3656846fc/pyuvsim/uvsim.py#L1156-L1162

The `uvdata_to_task_iter` function converts the task_id to the actual frequency, time, baseline, and src indices by using numpy's unravel_index:
https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/bcebb1407b6f60af7e53331a8410c2d3656846fc/pyuvsim/uvsim.py#L1043

This is also a generator function, so it returns a single task at a time instead of the full task array.

I started this branch on the plane on saturday, and rebased it off my other changes today. I haven't tested it on Oscar yet, because of issue #73 , but I think this should run faster and with less memory overhead than our current master branch. It's passing all unit tests, though probably still has formatting problems.