### PR TITLE
Herabeam workaround

### DIFF
--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -20,6 +20,33 @@ from .analyticbeam import AnalyticBeam
 from .mpi import rank
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 
+# Utilities for setting up simulations for parameter files,
+# and for generating parameter files from uvfits files
+
+def beam_string_to_object(beam_model):
+    """
+        Make a beam object given an identifying string.
+    """
+    # Identify analytic beams
+    if beam_model.startswith('gaussian'):
+        sigma = float(beam_model.split("_")[1])
+        return pyuvsim.AnalyticBeam('gaussian', sigma=sigma)
+    elif beam_model.startswith('airy'):
+        diameter = float(beam_model.split("_")[1])
+        return pyuvsim.AnalyticBeam('airy', sigma=diameter)
+    elif beam_model.startswith('uniform'):
+        return pyuvsim.AnalyticBeam('uniform')
+    if not os.path.exists(beam_model):
+        filename = beam_model
+        path = os.path.join(SIM_DATA_PATH, filename)
+        if not os.path.exists(path):
+            raise OSError("Could not find file " + filename)
+    else:
+        path = beam_model   # beam_model = path to beamfits
+    uvb = UVBeam()
+    uvb.read_beamfits(path)
+    return uvb
+
 
 def strip_extension(filepath):
     if '.' not in filepath:
@@ -306,32 +333,19 @@ def initialize_uvdata_from_params(obs_params):
         which_ants = antnames[np.where(beam_ids == beamID)]
         for a in which_ants:
             beam_dict[a] = beamID
-        uvb = UVBeam()
-        if beam_model in ['gaussian', 'uniform', 'airy']:
-            # Identify analytic beams
-            if beam_model == 'gaussian':
-                try:
-                    beam = AnalyticBeam('gaussian', sigma=telparam['sigma'])
-                except KeyError as err:
-                    raise KeyError("Missing sigma for gaussian beam.")
-            elif beam_model == 'airy':
-                try:
-                    beam = AnalyticBeam('airy', diameter=telparam['diameter'])
-                except KeyError as err:
-                    raise KeyError("Missing diameter for airy beam")
-            else:
-                beam = AnalyticBeam('uniform')
-            beam_list.append(beam)
-            continue
-        if not os.path.exists(beam_model):
-            filename = beam_model
-            path = os.path.join(SIM_DATA_PATH, filename)
-            if not os.path.exists(path):
-                raise OSError("Could not find file " + filename)
-        else:
-            path = beam_model   # beam_model = path to beamfits
-        uvb.read_beamfits(path)
-        beam_list.append(uvb)
+        if beam_model == 'gaussian':
+            try:
+                sigma = telparam['sigma']
+                beam_model = beam_model + '_' + str(sigma)
+            except KeyError:
+                raise KeyError("Missing sigma for gaussian beam.")
+        if beam_model == 'airy':
+            try:
+                diam = telparam['diameter']
+                beam_model = beam_model + '_' + str(diam)
+            except KeyError:
+                raise KeyError("Missing diameter for gaussian beam.")
+        beam_list.append(beam_model)
 
     param_dict['Nants_data'] = antnames.size
     param_dict['Nants_telescope'] = antnames.size

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -23,6 +23,7 @@ from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 # Utilities for setting up simulations for parameter files,
 # and for generating parameter files from uvfits files
 
+
 def beam_string_to_object(beam_model):
     """
         Make a beam object given an identifying string.

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -31,12 +31,12 @@ def beam_string_to_object(beam_model):
     # Identify analytic beams
     if beam_model.startswith('gaussian'):
         sigma = float(beam_model.split("_")[1])
-        return pyuvsim.AnalyticBeam('gaussian', sigma=sigma)
+        return AnalyticBeam('gaussian', sigma=sigma)
     elif beam_model.startswith('airy'):
         diameter = float(beam_model.split("_")[1])
-        return pyuvsim.AnalyticBeam('airy', sigma=diameter)
+        return AnalyticBeam('airy', sigma=diameter)
     elif beam_model.startswith('uniform'):
-        return pyuvsim.AnalyticBeam('uniform')
+        return AnalyticBeam('uniform')
     if not os.path.exists(beam_model):
         filename = beam_model
         path = os.path.join(SIM_DATA_PATH, filename)

--- a/pyuvsim/tests/profile_srcs.py
+++ b/pyuvsim/tests/profile_srcs.py
@@ -13,7 +13,7 @@ from astropy.coordinates import Angle, SkyCoord, EarthLocation, AltAz
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 import pyuvsim
 import yaml
-from pyuvsim import simsetup,create_mock_catalog,uvsim
+from pyuvsim import simsetup, create_mock_catalog, uvsim
 from guppy import hpy
 
 from mpi4py import MPI
@@ -22,7 +22,7 @@ from mpi4py import MPI
 comm = MPI.COMM_WORLD
 size = comm.Get_size()
 rank = comm.Get_rank()
-print("rank = ",rank,"PID",os.getpid())
+print("rank = ", rank, "PID", os.getpid())
 time = Time('2018-03-01 00:00:00', scale='utc')
 array_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',
                                    height=1073.)
@@ -33,14 +33,14 @@ pfile = '../data/laptop_size_sim.yaml'
 params = yaml.safe_load(open(pfile))
 print(pfile)
 input_uv, beam_list, beam_ids = simsetup.initialize_uvdata_from_params(params)
-#for a range of Nsrcs measure ram usage
+# for a range of Nsrcs measure ram usage
 #Ns = np.array([1,10,100])
 Ns = [10]
 process = psutil.Process(os.getpid())
 for Nsrcs in Ns:
-    #make the sources
-    catalog = create_mock_catalog(time,'long-line',Nsrcs=Nsrcs)
-    #run the thing
-    print("Nsrcs,",Nsrcs,"rank,",rank,"pre uvdata:", process.get_memory_info()[0]/1e6,"MB")
+    # make the sources
+    catalog = create_mock_catalog(time, 'long-line', Nsrcs=Nsrcs)
+    # run the thing
+    print("Nsrcs,", Nsrcs, "rank,", rank, "pre uvdata:", process.get_memory_info()[0] / 1e6, "MB")
     uvdata_out = uvsim.run_uvsim(input_uv, beam_list=beam_list, catalog=catalog)
-    print("Nsrcs,",Nsrcs,"rank,",rank,"post uvdata:", process.get_memory_info()[0]/1e6,"MB")
+    print("Nsrcs,", Nsrcs, "rank,", rank, "post uvdata:", process.get_memory_info()[0] / 1e6, "MB")

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -35,10 +35,13 @@ def test_run_uvsim():
                        feed_name='PAPER', feed_version='0.1', feed_pol=['x'],
                        model_name='E-field pattern - Rigging height 4.9m',
                        model_version='1.0')
+    beam.write_beamfits("temp.uvbeam")
+    beamfile = os.path.join(os.getcwd(), "temp.uvbeam")
 
-    beam_list = [beam]
-    mock_keywords = {"Nsrcs" : 3}
+    beam_list = [beamfile]
+    mock_keywords = {"Nsrcs": 3}
     uv_out = pyuvsim.run_uvsim(hera_uv, beam_list, catalog_file=None, mock_keywords=mock_keywords,
                                uvdata_file=EW_uvfits_file)
     if rank == 0:
         nt.assert_true(np.allclose(uv_out.data_array, hera_uv.data_array, atol=5e-3))
+    os.remove(beamfile)

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -42,9 +42,8 @@ def compare_dictionaries(dic1, dic2):
 def test_setup_airy():
     pyuvsim.initialize_uvdata_from_params(os.path.join(SIM_DATA_PATH,
                                                        'simple_equator_sim_airy.yaml'))
-    nt.assert_raises(KeyError,pyuvsim.initialize_uvdata_from_params,os.path.join(SIM_DATA_PATH,
-                                                                              'simple_equator_sim_airy_broken.yaml'))
-
+    nt.assert_raises(KeyError, pyuvsim.initialize_uvdata_from_params, os.path.join(SIM_DATA_PATH,
+                                                                                   'simple_equator_sim_airy_broken.yaml'))
 
 
 def test_param_reader():

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -75,7 +75,10 @@ def check_param_reader(config_num):
 
     # Check default configuration
     uv_obj, new_beam_list, new_beam_dict, beam_ids = pyuvsim.initialize_uvdata_from_params(param_filename)
+    for i, bm in enumerate(new_beam_list):
+        new_beam_list[i] = pyuvsim.simsetup.beam_string_to_object(bm)
     uvtask_list = pyuvsim.uvdata_to_task_list(uv_obj, sources, new_beam_list, beam_dict=new_beam_dict)
+
     # Tasks are not ordered in UVTask lists, so need to sort them.
     # This is enabled by the comparison operator in UVTask
     uvtask_list = sorted(uvtask_list)

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -21,6 +21,8 @@ import sys
 from scipy.special import jn
 import pickle
 
+import pyuvsim
+
 cst_files = ['HERA_NicCST_150MHz.txt', 'HERA_NicCST_123MHz.txt']
 beam_files = [os.path.join(DATA_PATH, f) for f in cst_files]
 hera_miriad_file = os.path.join(DATA_PATH, 'hera_testfile')
@@ -428,6 +430,7 @@ def test_uniform_beam():
     expected_data[0, 0, 0, :, :] = 1
     nt.assert_true(np.allclose(interpolated_beam, expected_data))
 
+
 @nt.nottest
 def test_airy_beam():
     diameter_m = 14.
@@ -467,10 +470,10 @@ def test_airy_beam():
         interp_zas[f_ind, :] = np.array(za_vals)
     #gaussian_vals = np.exp(-(interp_zas**2) / (2 * sigma_rad**2))
     za_grid, f_grid = np.meshgrid(interp_zas, freq_vals)
-    xvals = diameter_m/2.*np.sin(za_grid)*2.*np.pi*f_grid/3e8
+    xvals = diameter_m / 2. * np.sin(za_grid) * 2. * np.pi * f_grid / 3e8
     airy_vals = np.zeros_like(xvals)
-    airy_vals[xvals>0.] = 2.*jn(1,xvals[xvals>0.])/xvals[xvals>0.] 
-    airy_vals[xvals==0.] = 1.
+    airy_vals[xvals > 0.] = 2. * jn(1, xvals[xvals > 0.]) / xvals[xvals > 0.]
+    airy_vals[xvals == 0.] = 1.
 
     expected_data[1, 0, 0, :, :] = airy_vals
     expected_data[0, 0, 1, :, :] = airy_vals

--- a/scripts/run_param_pyuvsim.py
+++ b/scripts/run_param_pyuvsim.py
@@ -55,8 +55,6 @@ if rank == 0:
             beamfits_files = params['beam_files'].values()
             beam_list = []
             for bf in beamfits_files:
-                uvb = UVBeam()
-                uvb.read_beamfits()
                 beam_list.append(bf)
 
         beam_list = (np.array(beam_list)[beam_ids]).tolist()
@@ -83,6 +81,7 @@ if rank == 0:
             catalog = source_params['catalog']
         else:
             catalog = None
+beam_dict = comm.bcast(beam_dict, root=0)
 uvdata_out = pyuvsim.uvsim.run_uvsim(input_uv, beam_list=beam_list, beam_dict=beam_dict, catalog_file=catalog, mock_keywords=mock_keywords)
 
 if rank == 0:


### PR DESCRIPTION
This changes things up so that the beam objects are not instantiated until after the scatter, avoiding the MPI int overflow bug. It was branched off of reference_sim_changes.