### PR TITLE
Coherency basis rotation redux: DO NOT MERGE

### DIFF
--- a/pyuvsim/source.py
+++ b/pyuvsim/source.py
@@ -152,7 +152,6 @@ class Source(object):
 
         return coherency_local
 
-
     def alt_az_calc(self, time, telescope_location):
         """
         calculate the altitude & azimuth for this source at a time & location

--- a/pyuvsim/source.py
+++ b/pyuvsim/source.py
@@ -11,6 +11,7 @@ from astropy.coordinates import Angle, SkyCoord, EarthLocation, AltAz
 
 from .spherical_coordinates_basis_transformation import spherical_basis_transformation_components
 
+
 class Source(object):
     """
     Defines a single point source at a given ICRS ra/dec coordinate, with a
@@ -110,9 +111,9 @@ class Source(object):
             # Calculate the coherency transformation matrix
 
             # unit vectors to be transformed by astropy
-            x_c = np.array([1.,0,0])
-            y_c = np.array([0,1.,0])
-            z_c = np.array([0,0,1.])
+            x_c = np.array([1., 0, 0])
+            y_c = np.array([0, 1., 0])
+            z_c = np.array([0, 0, 1.])
 
             ''' We are using GCRS rather than ICRS to explicitly neglect the effect of aberration, which is a position-dependent
                 effect, and obtain a proper, orthgonal rotation matrix between the RA/Dec and Alt/Az coordinate systems.  It is
@@ -128,7 +129,7 @@ class Source(object):
             axes_altaz.representation = 'cartesian'
 
             # Test that this actually is a rotation matrix (i.e., orthogonal)
-            R = np.array(axes_altaz.cartesian.xyz) # the 3D rotation matrix that defines the mapping (RA,Dec) <--> (Alt,Az)
+            R = np.array(axes_altaz.cartesian.xyz)  # the 3D rotation matrix that defines the mapping (RA,Dec) <--> (Alt,Az)
 
             # This calculation is for a single point on the sphere.  The rotation_matrix below is different for every point
             # on the sphere.
@@ -136,11 +137,10 @@ class Source(object):
             cosX, sinX = spherical_basis_transformation_components(self.dec.rad, self.ra.rad, R)
             rotation_matrix = np.array([[cosX, sinX], [-sinX, cosX]])
 
-            alt_to_za = np.array([[-1.,0], [0,1]]) # ??? Supposedly fixes theta_hat points south for za and north for alt
+            alt_to_za = np.array([[-1., 0], [0, 1]]) # ??? Supposedly fixes theta_hat points south for za and north for alt
             basis_transformation_matrix = np.einsum('ab,bc->ac', alt_to_za, rotation_matrix)
 
-        coherency_local = np.einsum('ab,bc,cd->ad', basis_transformation_matrix.T,
-                                     self.coherency_radec, basis_transformation_matrix)
+        coherency_local = np.einsum('ab,bc,cd->ad', basis_transformation_matrix.T, self.coherency_radec, basis_transformation_matrix)
 
         return coherency_local
 

--- a/pyuvsim/source.py
+++ b/pyuvsim/source.py
@@ -138,7 +138,7 @@ class Source(object):
                              'value was: {al}'.format(al=telescope_location))
 
         if np.sum(np.abs(self.stokes[1:])) == 0:
-            basis_transformation_matrix = np.array([[1, 0], [0, 1]])
+            rotation_matrix = np.array([[1, 0], [0, 1]])
         else:
             # Calculate the coherency transformation matrix
             Rotation = self._calc_basis_rotation_matrix(time, telescope_location)
@@ -147,10 +147,8 @@ class Source(object):
             # on the sphere.
             rotation_matrix = self._calc_vector_rotation(Rotation)
 
-            alt_to_za = np.array([[-1., 0], [0, 1]])  # ??? Supposedly fixes theta_hat points south for za and north for alt
-            basis_transformation_matrix = np.einsum('ab,bc->ac', alt_to_za, rotation_matrix)
-
-        coherency_local = np.einsum('ab,bc,cd->ad', basis_transformation_matrix.T, self.coherency_radec, basis_transformation_matrix)
+        coherency_local = np.einsum('ab,bc,cd->ad', rotation_matrix.T,
+                                    self.coherency_radec, rotation_matrix)
 
         return coherency_local
 

--- a/pyuvsim/source.py
+++ b/pyuvsim/source.py
@@ -12,6 +12,7 @@ from astropy.coordinates import Angle, SkyCoord, EarthLocation, AltAz
 from .spherical_coordinates_basis_transformation import spherical_basis_transformation_components
 from . import utils
 
+
 class Source(object):
     """
     Defines a single point source at a given ICRS ra/dec coordinate, with a
@@ -146,7 +147,7 @@ class Source(object):
             # on the sphere.
             rotation_matrix = self._calc_vector_rotation(Rotation)
 
-            alt_to_za = np.array([[-1., 0], [0, 1]]) # ??? Supposedly fixes theta_hat points south for za and north for alt
+            alt_to_za = np.array([[-1., 0], [0, 1]])  # ??? Supposedly fixes theta_hat points south for za and north for alt
             basis_transformation_matrix = np.einsum('ab,bc->ac', alt_to_za, rotation_matrix)
 
         coherency_local = np.einsum('ab,bc,cd->ad', basis_transformation_matrix.T, self.coherency_radec, basis_transformation_matrix)

--- a/pyuvsim/spherical_coordinates_basis_transformation.py
+++ b/pyuvsim/spherical_coordinates_basis_transformation.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+def r_hat(theta,phi):
+    rhx = np.cos(phi) * np.cos(theta)
+    rhy = np.sin(phi) * np.cos(theta)
+    rhz = np.sin(theta)
+    return np.stack((rhx, rhy, rhz))
+
+def theta_hat(theta, phi):
+    thx = -np.cos(phi) * np.sin(theta)
+    thy = -np.sin(phi) * np.sin(theta)
+    thz = np.cos(theta)
+    return np.stack((thx, thy, thz))
+
+def phi_hat(theta, phi):
+    phx = -np.sin(phi)
+    phy = np.cos(phi)
+    phz = np.zeros_like(phi)
+    return np.stack((phx, phy, phz))
+
+def rotation_matrix(axis, angle):
+    """
+    Rodrigues' rotation matrix formula
+    """
+    K = np.array([
+        [0.,-axis[2], axis[1]],
+        [axis[2],0.,-axis[0]],
+        [-axis[1],axis[0],0.]
+    ])
+
+    I = np.identity(3)
+
+    R = I + np.sin(angle) * K + (1. - np.cos(angle)) * np.dot(K,K)
+
+    return R
+
+def spherical_coordinates_map(R, theta, phi):
+    """
+    Returns the spherical coordinates of the point specified by p = R . q,
+    where q is the 3D position vector of the point specified by (theta,phi) and
+    R is the 3D rotation matrix that relates two coordinate charts.
+    """
+    q_hat_1 = np.cos(phi) * np.cos(theta)
+    q_hat_2 = np.sin(phi) * np.cos(theta)
+    q_hat_3 = np.sin(theta)
+    q_hat = np.stack((q_hat_1,q_hat_2,q_hat_3))
+    p_hat = np.einsum('ab...,b...->a...',R ,q_hat)
+    beta = np.arcsin(p_hat[-1,:])
+    alpha = np.arctan2(p_hat[1,:],p_hat[0,:])
+    return (beta,alpha)
+
+def spherical_basis_transformation_components(theta, phi, R):
+
+    if np.allclose(R, np.eye(3)) == True:
+        cosX = np.ones_like(theta)
+        sinX = np.zeros_like(theta)
+
+    else:
+        beta, alpha = spherical_coordinates_map(R, theta, phi)
+
+        th = theta_hat(theta, phi)
+        ph = phi_hat(theta, phi)
+
+        bh = np.einsum('ab...,b...->a...', R.T, theta_hat(beta, alpha))
+        ah = np.einsum('ab...,b...->a...', R.T, phi_hat(beta, alpha))
+
+        cosX = np.einsum('a...,a...', bh, th)
+        sinX = np.einsum('a...,a...', bh, ph)
+
+    return cosX, sinX

--- a/pyuvsim/spherical_coordinates_basis_transformation.py
+++ b/pyuvsim/spherical_coordinates_basis_transformation.py
@@ -49,12 +49,13 @@ def spherical_coordinates_map(R, theta, phi):
     where q is the 3D position vector of the point specified by (theta,phi) and
     R is the 3D rotation matrix that relates two coordinate charts.
     """
-    q_hat_1 = np.cos(phi) * np.cos(theta)
-    q_hat_2 = np.sin(phi) * np.cos(theta)
-    q_hat_3 = np.sin(theta)
-    q_hat = np.stack((q_hat_1, q_hat_2, q_hat_3))
+    # q_hat_1 = np.cos(phi) * np.cos(theta)
+    # q_hat_2 = np.sin(phi) * np.cos(theta)
+    # q_hat_3 = np.sin(theta)
+    # q_hat = np.stack((q_hat_1, q_hat_2, q_hat_3))
+    q_hat = r_hat(theta, phi)
     p_hat = np.einsum('ab...,b...->a...', R, q_hat)
-    beta = np.arcsin(p_hat[-1])
+    beta = np.arcsin(p_hat[2])
     alpha = np.arctan2(p_hat[1], p_hat[0])
     return (beta, alpha)
 
@@ -77,4 +78,4 @@ def spherical_basis_transformation_components(theta, phi, R):
         cosX = np.einsum('a...,a...', bh, th)
         sinX = np.einsum('a...,a...', bh, ph)
 
-    return cosX, sinX
+    return cosX, sinX, th, ph, bh, ah, beta, alpha

--- a/pyuvsim/spherical_coordinates_basis_transformation.py
+++ b/pyuvsim/spherical_coordinates_basis_transformation.py
@@ -6,11 +6,13 @@ def r_hat(theta,phi):
     rhz = np.sin(theta)
     return np.stack((rhx, rhy, rhz))
 
+
 def theta_hat(theta, phi):
     thx = -np.cos(phi) * np.sin(theta)
     thy = -np.sin(phi) * np.sin(theta)
     thz = np.cos(theta)
     return np.stack((thx, thy, thz))
+
 
 def phi_hat(theta, phi):
     phx = -np.sin(phi)
@@ -18,21 +20,21 @@ def phi_hat(theta, phi):
     phz = np.zeros_like(phi)
     return np.stack((phx, phy, phz))
 
+
 def rotation_matrix(axis, angle):
     """
     Rodrigues' rotation matrix formula
     """
-    K = np.array([
-        [0.,-axis[2], axis[1]],
-        [axis[2],0.,-axis[0]],
-        [-axis[1],axis[0],0.]
-    ])
+    Kmatrix = np.array([[0., -axis[2], axis[1]],
+                        [axis[2], 0., -axis[0]],
+                        [-axis[1], axis[0], 0.]])
 
-    I = np.identity(3)
+    Identity = np.identity(3)
 
-    R = I + np.sin(angle) * K + (1. - np.cos(angle)) * np.dot(K,K)
+    Rotation = Identity + np.sin(angle) * Kmatrix + (1. - np.cos(angle)) * np.dot(Kmatrix, Kmatrix)
 
-    return R
+    return Rotation
+
 
 def spherical_coordinates_map(R, theta, phi):
     """
@@ -43,11 +45,12 @@ def spherical_coordinates_map(R, theta, phi):
     q_hat_1 = np.cos(phi) * np.cos(theta)
     q_hat_2 = np.sin(phi) * np.cos(theta)
     q_hat_3 = np.sin(theta)
-    q_hat = np.stack((q_hat_1,q_hat_2,q_hat_3))
-    p_hat = np.einsum('ab...,b...->a...',R ,q_hat)
-    beta = np.arcsin(p_hat[-1,:])
-    alpha = np.arctan2(p_hat[1,:],p_hat[0,:])
-    return (beta,alpha)
+    q_hat = np.stack((q_hat_1, q_hat_2, q_hat_3))
+    p_hat = np.einsum('ab...,b...->a...', R, q_hat)
+    beta = np.arcsin(p_hat[-1])
+    alpha = np.arctan2(p_hat[1], p_hat[0])
+    return (beta, alpha)
+
 
 def spherical_basis_transformation_components(theta, phi, R):
 

--- a/pyuvsim/spherical_coordinates_basis_transformation.py
+++ b/pyuvsim/spherical_coordinates_basis_transformation.py
@@ -34,14 +34,24 @@ def spherical_coordinates_map(R, theta, phi):
     where q is the 3D position vector of the point specified by (theta,phi) and
     R is the 3D rotation matrix that relates two coordinate charts.
     """
+    # This is NOT written to be vectorized for multiple (theta, phi)
+
+    # Replace with function call?
     q_hat_1 = np.cos(phi) * np.sin(theta)
     q_hat_2 = np.sin(phi) * np.sin(theta)
     q_hat_3 = np.cos(theta)
     q_hat = np.stack((q_hat_1, q_hat_2, q_hat_3))
+
     p_hat = np.einsum('ab...,b...->a...', R, q_hat)
-    beta = np.arccos(p_hat[-1, :])
-    alpha = np.arctan2(p_hat[1, :], p_hat[0, :])
-    alpha[alpha < 0] += 2. * np.pi
+    # Should test for shape of p_hat
+
+    # Should write a function to do this as well, i.e., pull back angles from
+    # a vector (or use healpix?)
+    beta = np.arccos(p_hat[2])
+    alpha = np.arctan2(p_hat[1], p_hat[0])
+    if alpha < 0:
+        alpha += 2. * np.pi
+    # alpha[alpha < 0] += 2. * np.pi
 
     return (beta, alpha)
 
@@ -58,4 +68,113 @@ def spherical_basis_transformation_components(theta, phi, R):
     cosX = np.einsum('a...,a...', bh, th)
     sinX = np.einsum('a...,a...', bh, ph)
 
-    return cosX, sinX
+    return cosX, sinX, th, ph, bh, ah, beta, alpha
+
+def spherical_basis_transformation_components2(beta, alpha, theta, phi, R):
+    #beta, alpha = spherical_coordinates_map(R, theta, phi)
+
+    th = theta_hat(theta, phi)
+    ph = phi_hat(theta, phi)
+
+    bh = np.einsum('ab...,b...->a...', R.T, theta_hat(beta, alpha))
+    ah = np.einsum('ab...,b...->a...', R.T, phi_hat(beta, alpha))
+
+    cosX = np.einsum('a...,a...', bh, th)
+    sinX = np.einsum('a...,a...', bh, ph)
+
+    return cosX, sinX, th, ph, bh, ah, beta, alpha
+
+def spherical_basis_transformation_components_two_points(beta, alpha, theta, phi, R):
+    #beta, alpha = spherical_coordinates_map(R, theta, phi)
+
+    th = theta_hat(theta, phi)
+    ph = phi_hat(theta, phi)
+
+    bh = np.einsum('ab...,b...->a...', R.T, theta_hat(beta, alpha))
+    ah = np.einsum('ab...,b...->a...', R.T, phi_hat(beta, alpha))
+
+    cosX = np.einsum('a...,a...', bh, th)
+    sinX = np.einsum('a...,a...', bh, ph)
+
+    return cosX, sinX #, th, ph, bh, ah, beta, alpha
+
+# From spherical_coordinates_basis_transformation in cst2ijones
+def axis_angle_rotation_matrix(axis, angle):
+    """
+    Rodrigues' rotation matrix formula
+    """
+    K = np.array([
+        [0.,-axis[2], axis[1]],
+        [axis[2],0.,-axis[0]],
+        [-axis[1],axis[0],0.]
+    ])
+
+    I = np.identity(3)
+
+    R = I + np.sin(angle) * K + (1. - np.cos(angle)) * np.dot(K,K)
+
+    return R
+
+def verify_orthogonal(R,tol=1e-15):
+    return np.allclose(np.matmul(R,R.T), np.eye(3), atol=tol)
+
+def verify_unit(v,tol=1e-15):
+    return np.allclose(np.dot(v,v), 1, atol=tol)
+
+def pts2rot(theta1, phi1, theta2, phi2):
+    """ Given two points on the sphere, find the rotation matrix that connects them.  
+    Probably done somewhere else better """
+    r1 = scbt.r_hat(theta1, phi1)
+    r2 = scbt.r_hat(theta2, phi2)
+    n = np.cross(r1,r2)
+    # Note that Psi is between 0 and pi
+    sinPsi = np.sqrt(np.dot(n,n))
+    n_hat = n/sinPsi # Trouble lurks if Psi = 0.
+    cosPsi = np.dot(r1,r2)
+    Psi = np.arctan2(sinPsi, cosPsi)
+    rotation = axis_angle_rotation_matrix(n_hat, Psi)
+    try:
+        assert(verify_unit(r1))
+        assert(verify_unit(r2))
+        assert(verify_unit(n_hat))
+        assert(verify_orthogonal(rotation))
+    except:
+        print('r1', r1)
+        print('r2', r2) 
+        print('n', n) 
+        print('len n', np.dot(n,n)) 
+        print('n_hat', n_hat) 
+        print('len n_hat', np.dot(n_hat,n_hat)) 
+        print('sinPsi', sinPsi) 
+        print('R', rotation) 
+        raise
+    return rotation
+
+def vecs2rot(r1, r2):
+    """ Given two vectors on the sphere, find the rotation matrix that connects them.  
+    Probably done somewhere else better """
+    #r1 = scbt.r_hat(theta1, phi1)
+    #r2 = scbt.r_hat(theta2, phi2)
+    n = np.cross(r1,r2)
+    # Note that Psi is between 0 and pi
+    sinPsi = np.sqrt(np.dot(n,n))
+    n_hat = n/sinPsi # Trouble lurks if Psi = 0.
+    cosPsi = np.dot(r1,r2)
+    Psi = np.arctan2(sinPsi, cosPsi)
+    rotation = axis_angle_rotation_matrix(n_hat, Psi)
+    try:
+        assert(verify_unit(r1))
+        assert(verify_unit(r2))
+        assert(verify_unit(n_hat))
+        assert(verify_orthogonal(rotation))
+    except:
+        print('r1', r1)
+        print('r2', r2) 
+        print('n', n) 
+        print('len n', np.dot(n,n)) 
+        print('n_hat', n_hat) 
+        print('len n_hat', np.dot(n_hat,n_hat)) 
+        print('sinPsi', sinPsi) 
+        print('R', rotation) 
+        raise
+    return rotation

--- a/pyuvsim/spherical_coordinates_basis_transformation.py
+++ b/pyuvsim/spherical_coordinates_basis_transformation.py
@@ -1,6 +1,13 @@
+# -*- mode: python; coding: utf-8 -*
+# Copyright (c) 2018 Radio Astronomy Software Group
+# Licensed under the 3-clause BSD License
+
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 
-def r_hat(theta,phi):
+
+def r_hat(theta, phi):
     rhx = np.cos(phi) * np.cos(theta)
     rhy = np.sin(phi) * np.cos(theta)
     rhz = np.sin(theta)
@@ -54,7 +61,7 @@ def spherical_coordinates_map(R, theta, phi):
 
 def spherical_basis_transformation_components(theta, phi, R):
 
-    if np.allclose(R, np.eye(3)) == True:
+    if np.allclose(R, np.eye(3)) is True:
         cosX = np.ones_like(theta)
         sinX = np.zeros_like(theta)
 

--- a/pyuvsim/tests/test_source.py
+++ b/pyuvsim/tests/test_source.py
@@ -22,6 +22,11 @@ def dummy_source(time, telescope_location):
 
 def test_calc_basis_rotation_matrix():
 
+    """
+    This tests whether the 3-D rotation matrix from RA/Dec to Alt/Az is
+    actually a rotation matrix (R R^T = R^T R = I)
+    """
+
     time = Time('2018-01-01 00:00')
     telescope_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s', height=1073.)
 
@@ -31,9 +36,16 @@ def test_calc_basis_rotation_matrix():
 
     # This is not a very strenous test :)
     assert(np.allclose(np.matmul(basis_rot_matrix, basis_rot_matrix.T), np.eye(3), atol=1.e-5))
+    assert(np.allclose(np.matmul(basis_rot_matrix.T, basis_rot_matrix), np.eye(3), atol=1.e-5))
 
 
 def test_calc_vector_rotation():
+
+    """
+    This checks that the 2-D coherency rotation matrix (which we call the
+    "vector" rotation) is unit determinant.  I suppose we could also have
+    checked (R R^T = R^T R = I)
+    """
 
     time = Time('2018-01-01 00:00')
     telescope_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s', height=1073.)

--- a/pyuvsim/tests/test_source.py
+++ b/pyuvsim/tests/test_source.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import nose.tools as nt
 from astropy.time import Time
-from astropy.coordinates import Angle, EarthLocation
+from astropy.coordinates import Angle, EarthLocation, SkyCoord
 from astropy import units
 
 import pyuvsim

--- a/pyuvsim/tests/test_source.py
+++ b/pyuvsim/tests/test_source.py
@@ -7,33 +7,36 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 import nose.tools as nt
 from astropy.time import Time
-from astropy.coordinates import Angle, SkyCoord, EarthLocation
+from astropy.coordinates import Angle, EarthLocation
 from astropy import units
 
 import pyuvsim
 import pyuvsim.tests as simtest
 from pyuvsim.source import Source
 
+
 def dummy_source(time, telescope_location):
 
-    return Source('Test',Angle(12.*units.hr),Angle(-30.*units.deg),150*units.MHz,[1.,0.,0.,0.])
+    return Source('Test', Angle(12. * units.hr), Angle(-30. * units.deg), 150 * units.MHz, [1., 0., 0., 0.])
+
 
 def test_calc_basis_rotation_matrix():
 
     time = Time('2018-01-01 00:00')
-    telescope_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',height=1073.)
+    telescope_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s', height=1073.)
 
     source = dummy_source(time, telescope_location)
 
     basis_rot_matrix = source._calc_basis_rotation_matrix(time, telescope_location)
 
     # This is not a very strenous test :)
-    assert(np.allclose(np.matmul(basis_rot_matrix, basis_rot_matrix.T),np.eye(3),atol=1.e-5))
+    assert(np.allclose(np.matmul(basis_rot_matrix, basis_rot_matrix.T), np.eye(3), atol=1.e-5))
+
 
 def test_calc_vector_rotation():
 
     time = Time('2018-01-01 00:00')
-    telescope_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',height=1073.)
+    telescope_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s', height=1073.)
 
     source = dummy_source(time, telescope_location)
 
@@ -41,7 +44,7 @@ def test_calc_vector_rotation():
 
     vector_rotation = source._calc_vector_rotation(basis_rot_matrix)
 
-    assert(np.isclose(np.linalg.det(vector_rotation),1,atol=1.e-5))
+    assert(np.isclose(np.linalg.det(vector_rotation), 1, atol=1.e-5))
 
 
 def test_source_zenith_from_icrs():

--- a/pyuvsim/tests/test_source.py
+++ b/pyuvsim/tests/test_source.py
@@ -12,6 +12,19 @@ from astropy import units
 
 import pyuvsim
 import pyuvsim.tests as simtest
+from pyuvsim.source import Source
+
+
+def test_calc_basis_rotation_matrix():
+    time = Time('2018-01-01 00:00')
+    telescope_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',height=1073.)
+
+    source = Source('Test',Angle(12.*units.hr),Angle(-30.*units.deg),150*units.MHz,[1.,0.,0.,0.])
+
+    basis_rot_matrix = source._calc_basis_rotation_matrix(time, telescope_location)
+
+    # This is not a very strenous test :)
+    assert(np.allclose(np.matmul(basis_rot_matrix, basis_rot_matrix.T),np.eye(3),atol=1.e-5))
 
 
 def test_source_zenith_from_icrs():

--- a/pyuvsim/tests/test_source.py
+++ b/pyuvsim/tests/test_source.py
@@ -14,17 +14,34 @@ import pyuvsim
 import pyuvsim.tests as simtest
 from pyuvsim.source import Source
 
+def dummy_source(time, telescope_location):
+
+    return Source('Test',Angle(12.*units.hr),Angle(-30.*units.deg),150*units.MHz,[1.,0.,0.,0.])
 
 def test_calc_basis_rotation_matrix():
+
     time = Time('2018-01-01 00:00')
     telescope_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',height=1073.)
 
-    source = Source('Test',Angle(12.*units.hr),Angle(-30.*units.deg),150*units.MHz,[1.,0.,0.,0.])
+    source = dummy_source(time, telescope_location)
 
     basis_rot_matrix = source._calc_basis_rotation_matrix(time, telescope_location)
 
     # This is not a very strenous test :)
     assert(np.allclose(np.matmul(basis_rot_matrix, basis_rot_matrix.T),np.eye(3),atol=1.e-5))
+
+def test_calc_vector_rotation():
+
+    time = Time('2018-01-01 00:00')
+    telescope_location = EarthLocation(lat='-30d43m17.5s', lon='21d25m41.9s',height=1073.)
+
+    source = dummy_source(time, telescope_location)
+
+    basis_rot_matrix = source._calc_basis_rotation_matrix(time, telescope_location)
+
+    vector_rotation = source._calc_vector_rotation(basis_rot_matrix)
+
+    assert(np.isclose(np.linalg.det(vector_rotation),1,atol=1.e-5))
 
 
 def test_source_zenith_from_icrs():

--- a/pyuvsim/tests/test_utils.py
+++ b/pyuvsim/tests/test_utils.py
@@ -21,7 +21,6 @@ import pyuvsim.tests as simtest
 triangle_uvfits_file = os.path.join(SIM_DATA_PATH, '28m_triangle_10time_10chan.uvfits')
 
 
-
 def test_stokes_to_coherency():
 
     stokesI = 4.5

--- a/pyuvsim/tests/test_utils.py
+++ b/pyuvsim/tests/test_utils.py
@@ -20,6 +20,18 @@ import pyuvsim.tests as simtest
 
 triangle_uvfits_file = os.path.join(SIM_DATA_PATH, '28m_triangle_10time_10chan.uvfits')
 
+def test_stokes_to_coherency():
+
+    I = 4.5
+    Q = -0.3
+    U = 1.2
+    V = -0.15
+    stokes = np.array([I, Q, U, V])
+    coherency = simutils.stokes_to_coherency(stokes)
+    back_to_stokes = simutils.coherency_to_stokes(coherency)
+
+    np.testing.assert_allclose(stokes, back_to_stokes)#, atol=1.e-5)
+
 
 def test_tee_ra_loop():
     time = Time(2457458.1739, scale='utc', format='jd')

--- a/pyuvsim/tests/test_utils.py
+++ b/pyuvsim/tests/test_utils.py
@@ -20,6 +20,7 @@ import pyuvsim.tests as simtest
 
 triangle_uvfits_file = os.path.join(SIM_DATA_PATH, '28m_triangle_10time_10chan.uvfits')
 
+
 def test_stokes_to_coherency():
 
     I = 4.5

--- a/pyuvsim/tests/test_utils.py
+++ b/pyuvsim/tests/test_utils.py
@@ -21,17 +21,18 @@ import pyuvsim.tests as simtest
 triangle_uvfits_file = os.path.join(SIM_DATA_PATH, '28m_triangle_10time_10chan.uvfits')
 
 
+
 def test_stokes_to_coherency():
 
-    I = 4.5
-    Q = -0.3
-    U = 1.2
-    V = -0.15
-    stokes = np.array([I, Q, U, V])
+    stokesI = 4.5
+    stokesQ = -0.3
+    stokesU = 1.2
+    stokesV = -0.15
+    stokes = np.array([stokesI, stokesQ, stokesU, stokesV])
     coherency = simutils.stokes_to_coherency(stokes)
     back_to_stokes = simutils.coherency_to_stokes(coherency)
 
-    np.testing.assert_allclose(stokes, back_to_stokes)#, atol=1.e-5)
+    np.testing.assert_allclose(stokes, back_to_stokes)  # , atol=1.e-5)
 
 
 def test_tee_ra_loop():

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -355,7 +355,7 @@ def test_offzenith_source_multibl_uvfits():
 
     beam_list = [beam]
 
-    baselines = [pyuvsim.Baseline(antenna2, antenna1),
+    baselines = [pyuvsim.Baselinel(antenna2, antenna1),
                  pyuvsim.Baseline(antenna3, antenna1),
                  pyuvsim.Baseline(antenna3, antenna2)]
     array = pyuvsim.Telescope('telescope_name', array_location, beam_list)

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -355,7 +355,7 @@ def test_offzenith_source_multibl_uvfits():
 
     beam_list = [beam]
 
-    baselines = [pyuvsim.Baselinel(antenna2, antenna1),
+    baselines = [pyuvsim.Baseline(antenna2, antenna1),
                  pyuvsim.Baseline(antenna3, antenna1),
                  pyuvsim.Baseline(antenna3, antenna2)]
     array = pyuvsim.Telescope('telescope_name', array_location, beam_list)

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import numpy as np
 import time as pytime
 import sys
 import os
@@ -240,3 +241,19 @@ def write_uvdata(uv_obj, param_dict, return_filename=False, dryrun=False, out_fo
             raise ValueError("Invalid output format. Options are \" uvfits\", \"uvh5\", or \"miriad\"")
     if return_filename:
         return outfile_name
+
+
+def stokes_to_coherency(stokes_vector):
+    ''' Takes vector of 4 Stokes parameters in order [I, Q, U , V] to equivalent coherency matrix '''
+    return .5 * np.array([[stokes_vector[0] + stokes_vector[1],
+                           stokes_vector[2] - 1j * stokes_vector[3]],
+                          [stokes_vector[2] + 1j * stokes_vector[3],
+                           stokes_vector[0] - stokes_vector[1]]])
+
+
+def coherency_to_stokes(coherency_matrix):
+    ''' Takes coherency matrix to vector of 4 Stokes parameter in order [I, Q, U , V] '''
+    return np.array([coherency_matrix[0,0] + coherency_matrix[1,1],
+                     coherency_matrix[0,0] - coherency_matrix[1,1],
+                     coherency_matrix[0,1] + coherency_matrix[1,0],
+                     (coherency_matrix[0,1] - coherency_matrix[1,0]).imag]).real

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -256,4 +256,4 @@ def coherency_to_stokes(coherency_matrix):
     return np.array([coherency_matrix[0,0] + coherency_matrix[1,1],
                      coherency_matrix[0,0] - coherency_matrix[1,1],
                      coherency_matrix[0,1] + coherency_matrix[1,0],
-                     (coherency_matrix[0,1] - coherency_matrix[1,0]).imag]).real
+                     -(coherency_matrix[0,1] - coherency_matrix[1,0]).imag]).real

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -253,7 +253,7 @@ def stokes_to_coherency(stokes_vector):
 
 def coherency_to_stokes(coherency_matrix):
     ''' Takes coherency matrix to vector of 4 Stokes parameter in order [I, Q, U , V] '''
-    return np.array([coherency_matrix[0,0] + coherency_matrix[1,1],
-                     coherency_matrix[0,0] - coherency_matrix[1,1],
-                     coherency_matrix[0,1] + coherency_matrix[1,0],
-                     -(coherency_matrix[0,1] - coherency_matrix[1,0]).imag]).real
+    return np.array([coherency_matrix[0, 0] + coherency_matrix[1, 1],
+                     coherency_matrix[0, 0] - coherency_matrix[1, 1],
+                     coherency_matrix[0, 1] + coherency_matrix[1, 0],
+                     -(coherency_matrix[0, 1] - coherency_matrix[1, 0]).imag]).real


### PR DESCRIPTION
Brought in Zac's code and did some parallel testing in a notebook.  Looks like obvious bugs are caught.  ~There is an open question about both azimuth and za/alt conventions for the signs.~

Need to add tests of the new calculation in source.py.

Fixes #2 