### PR TITLE
Redesign mpi imports and ensure MPI.Init is only run once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ install:
 script:
   - nosetests pyuvsim --with-coverage --cover-package=pyuvsim
   # unclear why this call needs to be different than in pyuvdata...
-  - pycodestyle  */*.py --ignore=E501,W503
+  - pycodestyle  */*.py --ignore=E501,W503 --exclude=./mpi.py
+  - pycodestyle  ./mpi.py --ignore=E501,W503,E402 --exclude=./mpi.py
 
 after_success:
   - coveralls

--- a/pyuvsim/mpi.py
+++ b/pyuvsim/mpi.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 import mpi4py
 import sys
 mpi4py.rc.initialize = False
+from mpi4py import MPI
 
 rank = 0
 Npus = 1
@@ -25,12 +26,10 @@ def set_mpi_excepthook(mpi_comm):
 
 def start_mpi():
     global comm, rank, Npus
-    try:
+    if not MPI.Is_initialized():
         # Avoid accidentally doing MPI_INIT twice
-        mpi4py.MPI.Init()
-    except mpi4py.MPI.Exception:
-        pass
-    comm = mpi4py.MPI.COMM_WORLD
+        MPI.Init()
+    comm = MPI.COMM_WORLD
     Npus = comm.Get_size()
     rank = comm.Get_rank()
     set_mpi_excepthook(comm)

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -28,6 +28,7 @@ singlesource_txt = os.path.join(SIM_DATA_PATH, 'single_source.txt')
 
 
 def test_run_uvsim():
+    print('test_run_uvsim')
     hera_uv = UVData()
     hera_uv.read_uvfits(EW_uvfits_file)
 
@@ -48,6 +49,7 @@ def test_run_uvsim():
 
 
 def test_run_param_uvsim():
+    print('test_run_param_uvsim')
     param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testcat.yaml')
     with open(param_filename, 'r') as pfile:
         params_dict = yaml.safe_load(pfile)
@@ -86,6 +88,7 @@ def test_run_param_uvsim():
 
 
 def test_mpi_funcs():
+    print('test_mpi_funcs')
     mpi.start_mpi()
     nt.assert_true(mpi.get_rank() == 0)
     nt.assert_true(mpi.get_Npus() == 1)


### PR DESCRIPTION
As it turns out, running MPI.Init() twice doesn't throw an exception but instead just causes an MPI error. I'm now aware of the MPI.Is_initialized() function, which makes this a lot simpler.

Unfortunately, I had to put a module level import _after_ setting mpi4py.rc.initialize=False. This breaks PEP8 rules, so I've changed the travis pycodestyle call to ignore E402 when checking `mpi.py`. This is really a flaw in mpi4py's design, which by default initializes MPI when imported...