### PR TITLE
Advanced profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- New batch scripts for profiling jobs on a SLURM-managed cluster, and plotting the results.
+
+### Changed
+- Line profiling may be done by running `pyuvsim.profiling.set_profiler`.
+- Which functions to profile is set by listing them by name, instead of by function decorators.
+- Improved test coverage
+
 
 ## [0.2.0] - 2018-10-26
 

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -21,7 +21,6 @@ class AnalyticBeam(object):
 
     supported_types = ['uniform', 'gaussian', 'airy']
 
-    @profile
     def __init__(self, type, sigma=None, diameter=None):
         if type in self.supported_types:
             self.type = type
@@ -35,7 +34,6 @@ class AnalyticBeam(object):
     def peak_normalize(self):
         pass
 
-    @profile
     def interp(self, az_array, za_array, freq_array, reuse_spline=None):
         """
         Evaluate the primary beam at given az, za locations (in radians).

--- a/pyuvsim/antenna.py
+++ b/pyuvsim/antenna.py
@@ -18,7 +18,6 @@ class Antenna(object):
     One of these defined for each antenna in the array.
     """
 
-    @profile
     def __init__(self, name, number, enu_position, beam_id):
         self.name = name
         self.number = number
@@ -27,7 +26,6 @@ class Antenna(object):
         # index of beam for this antenna from array.beam_list
         self.beam_id = beam_id
 
-    @profile
     def get_beam_jones(self, array, source_alt_az, frequency, reuse_spline=True):
         """
         2x2 array of Efield vectors in Az/Alt

--- a/pyuvsim/profiling.py
+++ b/pyuvsim/profiling.py
@@ -53,18 +53,18 @@ def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_pro
     # Add module functions to profiler.
     for mod_it in _pyuvsim.__dict__.values():
         if isfunction(mod_it):
-            if mod_it.func_name in func_list:
+            if mod_it.__name__ in func_list:
                 prof.add_function(mod_it)
         if isclass(mod_it):
             for item in mod_it.__dict__.values():
                 if isfunction(item):
-                    if item.func_name in func_list:
+                    if item.__name__ in func_list:
                         prof.add_function(item)
 
     builtins.__dict__['time_profiler'] = prof       # So it can accessed by tests
     # Write out profiling report to file.
     if get_rank() == rank:
-        ofile = file(outfile_name, 'w')
+        ofile = open(outfile_name, 'w')
         atexit.register(ofile.close)
         atexit.register(prof.print_stats, stream=ofile)
         if dump_raw:

--- a/pyuvsim/profiling.py
+++ b/pyuvsim/profiling.py
@@ -11,11 +11,12 @@ throughout the code will do line profiling on all instance methods.
 
 from __future__ import absolute_import, division, print_function
 
-import pyuvsim as _pyuvsim
 from .mpi import start_mpi, get_rank
 from inspect import isclass, isfunction
 import sys
 import atexit
+
+import pyuvsim as _pyuvsim
 
 try:
     from line_profiler import LineProfiler
@@ -34,19 +35,27 @@ prof = LineProfiler()
 
 default_profile_funcs = ['interp', 'get_beam_jones', 'initialize_uvdata_from_params', 'uvdata_to_telescope_config', 'uvdata_to_config_file', 'coherency_calc', 'alt_az_calc', 'apply_beam', 'make_visibility', 'uvdata_to_task_list', 'initialize_uvdata', 'run_uvsim']
 
-def set_profiler(func_list=default_profile_funcs):
-    if prof is not None:
+
+def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_profile.out'):
+    start_mpi()
+    if prof is None:
+        raise ImportError("line_profiler module required to use profiling tools.")
+
+    # Add module functions to profiler.
     for mod_it in _pyuvsim.__dict__.values():
+        if isfunction(mod_it):
+            if mod_it.func_name in func_list:
+                prof.add_function(mod_it)
         if isclass(mod_it):
-            for item in mod_it.__dict__.values()
-                if isfunction(item) and item in func_list:
-                    prof.add_function(item)
+            for item in mod_it.__dict__.values():
+                if isfunction(item):
+                    if item.func_name in func_list:
+                        prof.add_function(item)
 
-        atexit.register(prof.print_stats)
-
-
-# By default, the profile decorator has no effect.
-if 'profile' not in builtins.__dict__:
-    builtins.__dict__['profile'] = lambda f: f
-else:
-    set_profiler()  # Will activate if run with kernprof
+    # Write out profiling report to file.
+        if get_rank() == rank:
+            ofile = file(outfile_name, 'w')
+            builtins.__dict__['profiling_vars'] = [prof, ofile]
+            atexit.register(ofile.close)
+            atexit.register(prof.print_stats, stream=ofile)
+            prof.enable_by_count()

--- a/pyuvsim/profiling.py
+++ b/pyuvsim/profiling.py
@@ -11,8 +11,9 @@ throughout the code will do line profiling on all instance methods.
 
 from __future__ import absolute_import, division, print_function
 
+import pyuvsim as _pyuvsim
 from .mpi import start_mpi, get_rank
-import inspect
+from inspect import isclass, isfunction
 import sys
 import atexit
 
@@ -31,14 +32,17 @@ else:
 
 prof = LineProfiler()
 
+default_profile_funcs = ['interp', 'get_beam_jones', 'initialize_uvdata_from_params', 'uvdata_to_telescope_config', 'uvdata_to_config_file', 'coherency_calc', 'alt_az_calc', 'apply_beam', 'make_visibility', 'uvdata_to_task_list', 'initialize_uvdata', 'run_uvsim']
 
-def set_profiler():
-    """ If profiling is requested, then assign it to the builtins """
-    start_mpi()
+def set_profiler(func_list=default_profile_funcs):
     if prof is not None:
-        builtins.__dict__['profile'] = prof
-        if get_rank() == 0:
-            atexit.register(prof.print_stats)
+    for mod_it in _pyuvsim.__dict__.values():
+        if isclass(mod_it):
+            for item in mod_it.__dict__.values()
+                if isfunction(item) and item in func_list:
+                    prof.add_function(item)
+
+        atexit.register(prof.print_stats)
 
 
 # By default, the profile decorator has no effect.

--- a/pyuvsim/profiling.py
+++ b/pyuvsim/profiling.py
@@ -4,9 +4,6 @@
 
 """
 Use the line profiler when requested.
-
-If the set_profiler method is called, the profile decorators
-throughout the code will do line profiling on all instance methods.
 """
 
 from __future__ import absolute_import, division, print_function
@@ -36,9 +33,21 @@ prof = LineProfiler()
 default_profile_funcs = ['interp', 'get_beam_jones', 'initialize_uvdata_from_params', 'uvdata_to_telescope_config', 'uvdata_to_config_file', 'coherency_calc', 'alt_az_calc', 'apply_beam', 'make_visibility', 'uvdata_to_task_list', 'initialize_uvdata', 'run_uvsim']
 
 
-def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_profile.out'):
+def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_profile.out', dump_raw=False):
+    """
+    Applies a line profiler to the listed functions, wherever they appear in pyuvsim.
+
+    Places a LineProfiler object in the builtins list, and registers its dumping/printing functions to run
+    at the end.
+
+    Args:
+        func_list: list of function names (strings). Defaults to the list above.
+        rank: (int) Which rank process should write out to file? (only one rank at a time will). Default 0
+        outfile_name: Filename for printing profiling results.
+        dump_raw: Write out a pickled LineStats object to <outfile_name>.lprof (Default False)
+    """
     start_mpi()
-    if prof is None:
+    if prof is None:   # pragma: no cover
         raise ImportError("line_profiler module required to use profiling tools.")
 
     # Add module functions to profiler.
@@ -52,10 +61,14 @@ def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_pro
                     if item.func_name in func_list:
                         prof.add_function(item)
 
+    builtins.__dict__['time_profiler'] = prof       # So it can accessed by tests
     # Write out profiling report to file.
         if get_rank() == rank:
             ofile = file(outfile_name, 'w')
-            builtins.__dict__['profiling_vars'] = [prof, ofile]
             atexit.register(ofile.close)
             atexit.register(prof.print_stats, stream=ofile)
+            if dump_raw:
+                outfile_raw_name = outfile_name+".lprof"
+                atexit.register(prof.dump_stats, outfile_raw_name)
+
             prof.enable_by_count()

--- a/pyuvsim/profiling.py
+++ b/pyuvsim/profiling.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division, print_function
 from .mpi import start_mpi, get_rank
 from inspect import isclass, isfunction
 import atexit
+import six
 
 import pyuvsim as _pyuvsim
 
@@ -40,7 +41,7 @@ def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_pro
     start_mpi()
     global prof
     prof = LineProfiler()
-    if prof is None:
+    if prof is None:   # pragma: no cover
         raise ImportError("line_profiler module required to use profiling tools.")
 
     # Add module functions to profiler.
@@ -53,7 +54,7 @@ def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_pro
             for item in mod_it.__dict__.values():
                 if isfunction(item):
                     if item.__name__ in func_list:
-                        print("\t"+str(item))
+                        print("\t" + str(item))
                         prof.add_function(item)
 
     # Write out profiling report to file.
@@ -63,6 +64,8 @@ def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_pro
         atexit.register(prof.print_stats, stream=ofile)
         if dump_raw:
             outfile_raw_name = outfile_name + ".lprof"
+            if isinstance(dump_raw, six.string_types):
+                outfile_raw_name = dump_raw
             atexit.register(prof.dump_stats, outfile_raw_name)
 
         prof.enable_by_count()

--- a/pyuvsim/profiling.py
+++ b/pyuvsim/profiling.py
@@ -30,7 +30,7 @@ else:
 
 prof = LineProfiler()
 
-default_profile_funcs = ['interp', 'get_beam_jones', 'initialize_uvdata_from_params', 'uvdata_to_telescope_config', 'uvdata_to_config_file', 'coherency_calc', 'alt_az_calc', 'apply_beam', 'make_visibility', 'uvdata_to_task_list', 'initialize_uvdata', 'run_uvsim']
+default_profile_funcs = ['interp', 'get_beam_jones', 'initialize_uvdata_from_params', 'coherency_calc', 'alt_az_calc', 'apply_beam', 'make_visibility', 'uvdata_to_task_list', 'initialize_uvdata', 'run_uvsim']
 
 
 def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_profile.out', dump_raw=False):
@@ -63,12 +63,12 @@ def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_pro
 
     builtins.__dict__['time_profiler'] = prof       # So it can accessed by tests
     # Write out profiling report to file.
-        if get_rank() == rank:
-            ofile = file(outfile_name, 'w')
-            atexit.register(ofile.close)
-            atexit.register(prof.print_stats, stream=ofile)
-            if dump_raw:
-                outfile_raw_name = outfile_name+".lprof"
-                atexit.register(prof.dump_stats, outfile_raw_name)
+    if get_rank() == rank:
+        ofile = file(outfile_name, 'w')
+        atexit.register(ofile.close)
+        atexit.register(prof.print_stats, stream=ofile)
+        if dump_raw:
+            outfile_raw_name = outfile_name + ".lprof"
+            atexit.register(prof.dump_stats, outfile_raw_name)
 
-            prof.enable_by_count()
+        prof.enable_by_count()

--- a/pyuvsim/profiling.py
+++ b/pyuvsim/profiling.py
@@ -30,7 +30,7 @@ else:
 
 prof = LineProfiler()
 
-default_profile_funcs = ['interp', 'get_beam_jones', 'initialize_uvdata_from_params', 'coherency_calc', 'alt_az_calc', 'apply_beam', 'make_visibility', 'uvdata_to_task_list', 'initialize_uvdata', 'run_uvsim']
+default_profile_funcs = ['interp', 'get_beam_jones', 'initialize_uvdata_from_params', 'coherency_calc', 'alt_az_calc', 'apply_beam', 'make_visibility', 'uvdata_to_task_iter', 'init_uvdata_out', 'run_uvsim']
 
 
 def set_profiler(func_list=default_profile_funcs, rank=0, outfile_name='time_profile.out', dump_raw=False):

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -284,7 +284,6 @@ def create_mock_catalog(time, arrangement='zenith', array_location=None, Nsrcs=N
     return catalog, mock_keywords
 
 
-@profile
 def initialize_uvdata_from_params(obs_params):
     """
     Construct a uvdata object from parameters in a valid yaml file.
@@ -544,7 +543,6 @@ def initialize_uvdata_from_params(obs_params):
     return uv_obj, beam_list, beam_dict, beam_ids
 
 
-@profile
 def uvdata_to_telescope_config(uvdata_in, beam_filepath, layout_csv_name=None,
                                telescope_config_name=None,
                                return_names=False, path_out='.'):
@@ -615,7 +613,6 @@ def uvdata_to_telescope_config(uvdata_in, beam_filepath, layout_csv_name=None,
         return path_out, telescope_config_name, layout_csv_name
 
 
-@profile
 def uvdata_to_config_file(uvdata_in, param_filename=None, telescope_config_name='',
                           layout_csv_name='', catalog='mock', path_out='.'):
     """

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -582,7 +582,6 @@ def uvdata_to_telescope_config(uvdata_in, beam_filepath, layout_csv_name=None,
     beam_ids = np.zeros_like(e).astype(int)
     col_width = max([len(name) for name in uvdata_in.antenna_names])
     header = ("{:" + str(col_width) + "} {:8} {:8} {:10} {:10} {:10}\n").format("Name", "Number", "BeamID", "E", "N", "U")
-
     with open(os.path.join(path_out, layout_csv_name), 'w') as lfile:
         lfile.write(header + '\n')
         for i in range(beam_ids.size):

--- a/pyuvsim/source.py
+++ b/pyuvsim/source.py
@@ -72,7 +72,6 @@ class Source(object):
                                               [self.stokes[2] + 1j * self.stokes[3],
                                                self.stokes[0] - self.stokes[1]]])
 
-    @profile
     def coherency_calc(self, time, telescope_location):
         """
         Calculate the local coherency in alt/az basis for this source at a time & location.
@@ -119,7 +118,6 @@ class Source(object):
 
         return coherency_local
 
-    @profile
     def alt_az_calc(self, time, telescope_location):
         """
         calculate the altitude & azimuth for this source at a time & location
@@ -153,7 +151,6 @@ class Source(object):
         else:
             return self.alt_az
 
-    @profile
     def pos_lmn(self, time, telescope_location):
         """
         calculate the direction cosines of this source at a time & location

--- a/pyuvsim/tests/test_analyticbeam.py
+++ b/pyuvsim/tests/test_analyticbeam.py
@@ -212,3 +212,18 @@ def test_gaussbeam_values():
 
     beam_values = np.exp(-(zenith_angles)**2 / (2 * beam.sigma**2))
     nt.assert_true(np.all(beam_values**2 == coherencies))
+
+
+def test_beamerrs():
+    """
+    Error cases.
+    """
+    nt.assert_raises(ValueError, pyuvsim.AnalyticBeam, 'unsupported_type')
+    beam = pyuvsim.AnalyticBeam('gaussian')
+    az, za = np.random.uniform(0.0, np.pi, (2, 5))
+    freq_arr = np.linspace(1e8, 1.5e8, 10)
+    nt.assert_raises(ValueError, beam.interp, az, za, freq_arr)
+    beam.type = 'airy'
+    nt.assert_raises(ValueError, beam.interp, az, za, freq_arr)
+    beam.type = 'noninterpretable'
+    nt.assert_raises(ValueError, beam.interp, az, za, freq_arr)

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -45,6 +45,7 @@ def test_run_uvsim():
 
     beam_list = [beamfile]
     mock_keywords = {"Nsrcs": 3}
+    nt.assert_raises(TypeError, pyuvsim.run_uvsim, 'not_uvdata', beam_list)
     uv_out = pyuvsim.run_uvsim(hera_uv, beam_list, catalog_file=None, mock_keywords=mock_keywords,
                                uvdata_file=EW_uvfits_file)
     rank = mpi.get_rank()

--- a/pyuvsim/tests/test_profiler.py
+++ b/pyuvsim/tests/test_profiler.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function
 
 import os
-import sys
 import yaml
 import numpy as np
 import nose.tools as nt
@@ -17,19 +16,10 @@ try:
 except ImportError:
     LineProfiler = False
 
-PY3 = sys.version_info[0] == 3
-
-if PY3:
-    import builtins
-    import _pickle as pkl
-else:
-    import __builtin__ as builtins
-    import cPickle as pkl
-
 testprof_fname = '/dev/null'
 
 
-def test_profiling():
+def test_profiler():
     if LineProfiler:
         pyuvsim.profiling.set_profiler(outfile_name=testprof_fname)
         param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testcat.yaml')
@@ -40,10 +30,10 @@ def test_profiling():
         catalog = os.path.join(SIM_DATA_PATH, params_dict['sources']['catalog'])
         uv_out = pyuvsim.run_uvsim(uv_in, beam_list, catalog_file=catalog, beam_dict=beam_dict)
 
-        # The profiler is in the builtins as time_profiler. Check results.
+        time_profiler = pyuvsim.profiling.get_profiler()
         lstats = time_profiler.get_stats()
-        del builtins.__dict__['time_profiler']  # Remove from builtins
 
         nt.assert_false(len(lstats.timings) == 0)
         func_names = [k[2] for k in lstats.timings.keys()]
         nt.assert_equal(np.unique(func_names).tolist(), sorted(pyuvsim.profiling.default_profile_funcs))
+        time_profiler.disable()

--- a/pyuvsim/tests/test_profiler.py
+++ b/pyuvsim/tests/test_profiler.py
@@ -5,7 +5,11 @@
 from __future__ import absolute_import, division, print_function
 
 import pyuvsim
-
+try:
+    from line_profiler import LineProfiler
+except ImportError:
+    LineProfiler=False
 
 def test_profiling():
-    pyuvsim.profiling.set_profiler()
+    if LineProfiler:
+        pyuvsim.profiling.set_profiler()

--- a/pyuvsim/tests/test_profiler.py
+++ b/pyuvsim/tests/test_profiler.py
@@ -36,7 +36,7 @@ def test_profiling():
         with open(param_filename, 'r') as pfile:
             params_dict = yaml.safe_load(pfile)
         uv_in, beam_list, beam_dict, beam_ids = pyuvsim.simsetup.initialize_uvdata_from_params(param_filename)
-        beam_list[0] = pyuvsim.analyticbeam.AnalyticBeam('uniform')  # Replace the one that's a HERA beam
+        beam_list[0] = 'uniform'  # Replace the one that's a HERA beam
         catalog = os.path.join(SIM_DATA_PATH, params_dict['sources']['catalog'])
         uv_out = pyuvsim.run_uvsim(uv_in, beam_list, catalog_file=catalog, beam_dict=beam_dict)
 

--- a/pyuvsim/tests/test_profiler.py
+++ b/pyuvsim/tests/test_profiler.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 import yaml
-import cPickle as pkl
 import numpy as np
 import nose.tools as nt
 import atexit
@@ -23,8 +22,10 @@ PY3 = sys.version_info[0] == 3
 
 if PY3:
     import builtins
+    import _pickle as pkl
 else:
     import __builtin__ as builtins
+    import cPickle as pkl
 
 testprof_fname = 'test_time_profile.out'
 

--- a/pyuvsim/tests/test_profiler.py
+++ b/pyuvsim/tests/test_profiler.py
@@ -9,7 +9,6 @@ import sys
 import yaml
 import numpy as np
 import nose.tools as nt
-import atexit
 
 import pyuvsim
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
@@ -27,7 +26,7 @@ else:
     import __builtin__ as builtins
     import cPickle as pkl
 
-testprof_fname = 'test_time_profile.out'
+testprof_fname = '/dev/null'
 
 
 def test_profiling():
@@ -48,4 +47,3 @@ def test_profiling():
         func_names = [k[2] for k in lstats.timings.keys()]
         nt.assert_equal(np.unique(func_names).tolist(), sorted(pyuvsim.profiling.default_profile_funcs))
         # To clean up later. Profiling data isn't written to file until exit.
-        atexit.register(os.remove, testprof_fname)

--- a/pyuvsim/tests/test_profiler.py
+++ b/pyuvsim/tests/test_profiler.py
@@ -4,12 +4,47 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os
+import sys
+import yaml
+import cPickle as pkl
+import numpy as np
+import nose.tools as nt
+import atexit
+
 import pyuvsim
+from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 try:
     from line_profiler import LineProfiler
 except ImportError:
-    LineProfiler=False
+    LineProfiler = False
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    import builtins
+else:
+    import __builtin__ as builtins
+
+testprof_fname = 'test_time_profile.out'
+
 
 def test_profiling():
     if LineProfiler:
-        pyuvsim.profiling.set_profiler()
+        pyuvsim.profiling.set_profiler(outfile_name=testprof_fname)
+        param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testcat.yaml')
+        with open(param_filename, 'r') as pfile:
+            params_dict = yaml.safe_load(pfile)
+        uv_in, beam_list, beam_dict, beam_ids = pyuvsim.simsetup.initialize_uvdata_from_params(param_filename)
+        beam_list[0] = pyuvsim.analyticbeam.AnalyticBeam('uniform')  # Replace the one that's a HERA beam
+        catalog = os.path.join(SIM_DATA_PATH, params_dict['sources']['catalog'])
+        uv_out = pyuvsim.run_uvsim(uv_in, beam_list, catalog_file=catalog, beam_dict=beam_dict)
+
+        # The profiler is in the builtins as time_profiler. Check results.
+        lstats = time_profiler.get_stats()
+
+        nt.assert_false(len(lstats.timings) == 0)
+        func_names = [k[2] for k in lstats.timings.keys()]
+        nt.assert_equal(np.unique(func_names).tolist(), sorted(pyuvsim.profiling.default_profile_funcs))
+        # To clean up later. Profiling data isn't written to file until exit.
+        atexit.register(os.remove, testprof_fname)

--- a/pyuvsim/tests/test_profiler.py
+++ b/pyuvsim/tests/test_profiler.py
@@ -42,8 +42,8 @@ def test_profiling():
 
         # The profiler is in the builtins as time_profiler. Check results.
         lstats = time_profiler.get_stats()
+        del builtins.__dict__['time_profiler']  # Remove from builtins
 
         nt.assert_false(len(lstats.timings) == 0)
         func_names = [k[2] for k in lstats.timings.keys()]
         nt.assert_equal(np.unique(func_names).tolist(), sorted(pyuvsim.profiling.default_profile_funcs))
-        # To clean up later. Profiling data isn't written to file until exit.

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -618,9 +618,9 @@ def test_local_task_gen():
 
     # Check error conditions
     uv_iter0 = pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), 'not_uvdata', sources, beam_list, beam_dict)
-    nt.assert_raises(TypeError, uv_iter0.next)
+    nt.assert_raises(TypeError, next, uv_iter0)
     uv_iter1 = pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), hera_uv, 'not_ndarray', beam_list, beam_dict)
-    nt.assert_raises(TypeError, uv_iter1.next)
+    nt.assert_raises(TypeError, next, uv_iter1)
 
     engine0 = pyuvsim.UVEngine(reuse_spline=False)
     for tki, task0 in enumerate(uvtask_iter):

--- a/pyuvsim/tests/test_z_profiler.py
+++ b/pyuvsim/tests/test_z_profiler.py
@@ -11,6 +11,7 @@ import nose.tools as nt
 
 import pyuvsim
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
+
 try:
     from line_profiler import LineProfiler
 except ImportError:
@@ -21,7 +22,7 @@ testprof_fname = '/dev/null'
 
 def test_profiler():
     if LineProfiler:
-        pyuvsim.profiling.set_profiler(outfile_name=testprof_fname)
+        pyuvsim.profiling.set_profiler(outfile_name=testprof_fname, dump_raw='/dev/null')
         param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testcat.yaml')
         with open(param_filename, 'r') as pfile:
             params_dict = yaml.safe_load(pfile)
@@ -31,6 +32,7 @@ def test_profiler():
         uv_out = pyuvsim.run_uvsim(uv_in, beam_list, catalog_file=catalog, beam_dict=beam_dict)
 
         time_profiler = pyuvsim.profiling.get_profiler()
+        nt.assert_true(isinstance(time_profiler, LineProfiler))
         lstats = time_profiler.get_stats()
 
         nt.assert_false(len(lstats.timings) == 0)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -154,7 +154,6 @@ def uvdata_to_task_iter(task_ids, input_uv, catalog, beam_list, beam_dict):
 
     # Loops, outer to inner: times, sources, frequencies, baselines
     # The task_ids refer to tasks on the flattened meshgrid.
-
     if not isinstance(input_uv, UVData):
         raise TypeError("input_uv must be UVData object")
 
@@ -289,7 +288,7 @@ def init_uvdata_out(uv_in, source_list_name, uvdata_file=None,
     else:
         # Note: currently only support a constant spacing of times
         uv_obj.integration_time = (np.ones_like(uv_obj.time_array, dtype=np.float64)
-                                   * np.diff(np.unique(uv_obj.time_array))[0])
+                                   * np.diff(np.unique(uv_obj.time_array))[0] * (24. * 60**2))  # Seconds
     # add pyuvdata version info
     history += uv_obj.pyuvdata_version_str
 
@@ -358,15 +357,12 @@ def run_uvsim(input_uv, beam_list, beam_dict=None, catalog_file=None,
                 mock_keywords = {}
 
             if 'array_location' not in mock_keywords:
+                warnings.warn("Warning: No array_location given for mock catalog. Defaulting to HERA site")
                 array_loc = EarthLocation.from_geocentric(*input_uv.telescope_location, unit='m')
                 mock_keywords['array_location'] = array_loc
             if 'time' not in mock_keywords:
-                mock_keywords['time'] = input_uv.time_array[0]
-
-            if "array_location" not in mock_keywords:
-                warnings.warn("Warning: No array_location given for mock catalog. Defaulting to HERA site")
-            if 'time' not in mock_keywords:
                 warnings.warn("Warning: No julian date given for mock catalog. Defaulting to first of input_UV object")
+                mock_keywords['time'] = input_uv.time_array[0]
 
             time = mock_keywords.pop('time')
 

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -218,16 +218,9 @@ def uvdata_to_task_iter(task_ids, input_uv, catalog, beam_list, beam_dict):
         yield task
 
 
-<<<<<<< HEAD
-@profile
 def init_uvdata_out(uv_in, source_list_name, uvdata_file=None,
                     obs_param_file=None, telescope_config_file=None,
                     antenna_location_file=None):
-=======
-def initialize_uvdata(uvtask_list, source_list_name, uvdata_file=None,
-                      obs_param_file=None, telescope_config_file=None,
-                      antenna_location_file=None):
->>>>>>> fb704ed... Remove profile decorators and allow function selection by name
     """
     Initialize an empty uvdata object to fill with simulated data.
     Args:

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -93,7 +93,6 @@ class UVEngine(object):
     def set_task(self, task):
         self.task = task
 
-    @profile
     def apply_beam(self):
         """ Get apparent coherency from jones matrices and source coherency. """
         baseline = self.task.baseline
@@ -119,7 +118,6 @@ class UVEngine(object):
 
         self.apparent_coherency = this_apparent_coherency
 
-    @profile
     def make_visibility(self):
         """ Visibility contribution from a single source """
         assert(isinstance(self.task.freq, Quantity))
@@ -139,7 +137,6 @@ class UVEngine(object):
         return np.array(vis_vector)
 
 
-@profile
 def uvdata_to_task_iter(task_ids, input_uv, catalog, beam_list, beam_dict):
     """
     Generate local tasks, reusing quantities where possible.
@@ -221,10 +218,16 @@ def uvdata_to_task_iter(task_ids, input_uv, catalog, beam_list, beam_dict):
         yield task
 
 
+<<<<<<< HEAD
 @profile
 def init_uvdata_out(uv_in, source_list_name, uvdata_file=None,
                     obs_param_file=None, telescope_config_file=None,
                     antenna_location_file=None):
+=======
+def initialize_uvdata(uvtask_list, source_list_name, uvdata_file=None,
+                      obs_param_file=None, telescope_config_file=None,
+                      antenna_location_file=None):
+>>>>>>> fb704ed... Remove profile decorators and allow function selection by name
     """
     Initialize an empty uvdata object to fill with simulated data.
     Args:
@@ -320,7 +323,6 @@ def serial_gather(uvtask_list, uv_out):
     return uv_out
 
 
-@profile
 def run_uvsim(input_uv, beam_list, beam_dict=None, catalog_file=None,
               mock_keywords=None,
               uvdata_file=None, obs_param_file=None,

--- a/scripts/batch_profile_job.sh
+++ b/scripts/batch_profile_job.sh
@@ -6,13 +6,13 @@
 #SBATCH -J pyuvsim_profile
 #SBATCH --array=0-0
 
-#echo JOBID ${SLURM_ARRAY_JOB_ID}
-#echo TASKID ${SLURM_ARRAY_TASK_ID}
-#
-#ntasks=${SLURM_NTASKS}
-#nnodes=${SLURM_JOB_NUM_NODES}
-#task=${SLURM_ARRAY_TASK_ID}
-#jobid=${SLURM_ARRAY_JOB_ID}
+echo JOBID ${SLURM_ARRAY_JOB_ID}
+echo TASKID ${SLURM_ARRAY_TASK_ID}
+
+ntasks=${SLURM_NTASKS}
+nnodes=${SLURM_JOB_NUM_NODES}
+task=${SLURM_ARRAY_TASK_ID}
+jobid=${SLURM_ARRAY_JOB_ID}
 
 branch=`git branch | grep \* | cut -d ' ' -f2`
 
@@ -22,7 +22,7 @@ read -r -a Nsrcs <<< "$1"
 read -r -a Ntimes <<< "$2"
 read -r -a Nfreqs <<< "$3"
 read -r -a Nbls <<< "$4"
-read -r -a beam <<< "$5"
+read -r -a beams <<< "$5"
 IFS=$_IFS
 
 echo ${Ntimes[@]}
@@ -33,12 +33,32 @@ if [ ! -d "$dir1" ]; then
     mkdir -p $dir1
 fi
 
-START=$(date +%s)   # Timing
-if [ "$task" -eq '0' ]; then
-    srun --mpi=pmi2 python run_profile_pyuvsim.py --Nsrcs $nsrcs --Ntimes $ntimes --Nfreqs $nfreqs --Nbls $nbls --beam $beam --prof_out $dir1/time_profile.out
+slids_out="slurm_ids_"$branch".out"
+if [ ! -f $slids_out ]; then
+   echo 'Npus, Nnodes, Nsrcs, Ntimes, Nfreqs, Nbls, beam, MaxMem, Elapsed' > $slids_out
 fi
-END=$(date +%s)
-DIFF=$(( $END - $START ))
+
+for nsrcs in "${Nsrcs[@]}"; do
+    for ntimes in "${Ntimes[@]}"; do
+        for nfreqs in "${Nfreqs[@]}"; do
+            for nbls in "${Nbls[@]}"; do
+                for beam in "${beams[@]}"; do
+                    START=$(date +%s)   # Timing
+                    if [ "$task" -eq '0' ]; then
+                        srun --mpi=pmi2 python run_profile_pyuvsim.py --Nsrcs $nsrcs --Ntimes $ntimes --Nfreqs $nfreqs --Nbls $nbls --beam $beam \
+                                --prof_out $dir1/time_profile.out --mem_out $dir1/memory_usage.out
+                    fi
+                    END=$(date +%s)
+                    DIFF=$(( $END - $START ))
+                    mem_used=$(<$dir1'/memory_usage.out')
+                    echo $ntasks", "$nnodes', '$nsrcs', '$ntimes', '$nfreqs', '$nbls', '$beam', '$mem_used', '$DIFF
+                done
+            done
+        done
+    done
+done
+
+rm $dir1'/memory_usage.out'
 
 ## Try to clean up the scripts directory
 ofilename='slurm-'$jobid'_'$task'.out'

--- a/scripts/batch_profile_job.sh
+++ b/scripts/batch_profile_job.sh
@@ -6,36 +6,39 @@
 #SBATCH -J pyuvsim_profile
 #SBATCH --array=0-0
 
-echo JOBID ${SLURM_ARRAY_JOB_ID}
-echo TASKID ${SLURM_ARRAY_TASK_ID}
-
-ntasks=${SLURM_NTASKS}
-nnodes=${SLURM_JOB_NUM_NODES}
-task=${SLURM_ARRAY_TASK_ID}
-jobid=${SLURM_ARRAY_JOB_ID}
-
-if [ "$#" -ne 5 ]; then
-    echo 'Usage: sbatch batch_pyuvsim.sh <Nsrcs> <Ntimes> <Nfreqs> <Nbls> <beam>'
-    exit
-fi
+#echo JOBID ${SLURM_ARRAY_JOB_ID}
+#echo TASKID ${SLURM_ARRAY_TASK_ID}
+#
+#ntasks=${SLURM_NTASKS}
+#nnodes=${SLURM_JOB_NUM_NODES}
+#task=${SLURM_ARRAY_TASK_ID}
+#jobid=${SLURM_ARRAY_JOB_ID}
 
 branch=`git branch | grep \* | cut -d ' ' -f2`
 
-nsrcs=$1
-ntimes=$2
-nfreqs=$3
-nbls=$4
-beam=$5
+_IFS=$IFS
+IFS=','
+read -r -a Nsrcs <<< "$1"
+read -r -a Ntimes <<< "$2"
+read -r -a Nfreqs <<< "$3"
+read -r -a Nbls <<< "$4"
+read -r -a beam <<< "$5"
+IFS=$_IFS
 
-dir1=$branch'_profiling/sim_'$nsrcs'src_'$nfreqs'freq_'$ntimes'time_'$nbls'bls_'$beam'beam_'$nnodes'nodes_'$ntasks'cpus'
+echo ${Ntimes[@]}
 
+dir1=$branch'_profiling/sim_'$nnodes'nodes_'$ntasks'cpus'
+#
 if [ ! -d "$dir1" ]; then
     mkdir -p $dir1
 fi
 
+START=$(date +%s)   # Timing
 if [ "$task" -eq '0' ]; then
-    srun --mpi=pmi2 kernprof -l -v run_profile_pyuvsim.py --Nsrcs $nsrcs --Ntimes $ntimes --Nfreqs $nfreqs --Nbls $nbls --beam $beam > $dir1/time_profile.out
+    srun --mpi=pmi2 python run_profile_pyuvsim.py --Nsrcs $nsrcs --Ntimes $ntimes --Nfreqs $nfreqs --Nbls $nbls --beam $beam --prof_out $dir1/time_profile.out
 fi
+END=$(date +%s)
+DIFF=$(( $END - $START ))
 
 ## Try to clean up the scripts directory
 ofilename='slurm-'$jobid'_'$task'.out'

--- a/scripts/do_batch_profiling.py
+++ b/scripts/do_batch_profiling.py
@@ -10,7 +10,10 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import subprocess
+<<<<<<< HEAD
 from pyuvsim.utils import check_file_exists_and_increment
+=======
+>>>>>>> 8f8d834... Loop within bash jobscript, need memory_profiler
 
 Nsrcs = [5, 10, 20]
 Ntimes = [1, 5, 10, 15]
@@ -18,11 +21,13 @@ Nfreqs = [1, 5, 10, 15]
 Nbls = [10, 20, 50]
 beam = ['uniform', 'hera']
 
-Nsrcs, Ntimes, Nfreqs, Nbls, beam = map(np.ndarray.flatten, np.meshgrid(Nsrcs, Ntimes, Nfreqs, Nbls, beam))
-
-Nconfigs = Nsrcs.size
-
 Ncores = [8, 16, 32, 64]
+
+Nsrcs = ','.join(map(str, Nsrcs))
+Ntimes = ','.join(map(str, Ntimes))
+Nfreqs = ','.join(map(str, Nfreqs))
+Nbls = ','.join(map(str, Nbls))
+beam = ','.join(map(str, beam))
 
 mem = '40G'
 time = '48:00:00'
@@ -35,22 +40,17 @@ fname = check_file_exists_and_increment(git_branch + '_slurm_ids.out')
 sids_out = open(fname, 'w')
 sids_out.write('Nsrcs, Ntimes, Nfreqs, Nbls, beam, slurm_id\n')
 for n in Ncores:
-    for i in range(Nconfigs):
-        cmd = ['sbatch', '-n ' + str(n), '--cpus-per-task=1', '--mem=' + mem, '--time=' + time,
-               'batch_profile_job.sh',
-               str(Nsrcs[i]),
-               str(Ntimes[i]),
-               str(Nfreqs[i]),
-               str(Nbls[i]),
-               str(beam[i])]
-        print(" ".join(cmd))
-        results = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-        print(results)
-        slurm_id = results.strip().split(' ')[-1]
-        parms = [
-            str(Nsrcs[i]),
-            str(Ntimes[i]),
-            str(Nfreqs[i]),
-            str(Nbls[i]),
-            str(beam[i])]
-        sids_out.write(','.join(parms) + ',' + slurm_id + '\n')
+    #cmd = ['sbatch', '-n ' + str(n), '--cpus-per-task=1', '--mem=' + mem, '--time=' + time,
+    #       'batch_profile_job.sh', Nsrcs, Ntimes, Nfreqs, Nbls, beam]
+    cmd = ['./batch_profile_job.sh', Nsrcs, Ntimes, Nfreqs, Nbls, beam]
+    print(" ".join(cmd))
+    results = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    print(results)
+#    slurm_id = results.strip().split(' ')[-1]
+#    parms = [
+#        str(Nsrcs[i]),
+#        str(Ntimes[i]),
+#        str(Nfreqs[i]),
+#        str(Nbls[i]),
+#        str(beam[i])]
+#    sids_out.write(','.join(parms) + ',' + slurm_id + '\n')

--- a/scripts/do_batch_profiling.py
+++ b/scripts/do_batch_profiling.py
@@ -10,10 +10,6 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import subprocess
-<<<<<<< HEAD
-from pyuvsim.utils import check_file_exists_and_increment
-=======
->>>>>>> 8f8d834... Loop within bash jobscript, need memory_profiler
 
 Nsrcs = [5, 10, 20]
 Ntimes = [1, 5, 10, 15]
@@ -32,25 +28,8 @@ beam = ','.join(map(str, beam))
 mem = '40G'
 time = '48:00:00'
 
-output = subprocess.check_output('git branch | grep \\* | cut -d \' \' -f2', shell=True)
-git_branch = output.strip()
-
-fname = check_file_exists_and_increment(git_branch + '_slurm_ids.out')
-
-sids_out = open(fname, 'w')
-sids_out.write('Nsrcs, Ntimes, Nfreqs, Nbls, beam, slurm_id\n')
 for n in Ncores:
-    #cmd = ['sbatch', '-n ' + str(n), '--cpus-per-task=1', '--mem=' + mem, '--time=' + time,
-    #       'batch_profile_job.sh', Nsrcs, Ntimes, Nfreqs, Nbls, beam]
     cmd = ['./batch_profile_job.sh', Nsrcs, Ntimes, Nfreqs, Nbls, beam]
     print(" ".join(cmd))
     results = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     print(results)
-#    slurm_id = results.strip().split(' ')[-1]
-#    parms = [
-#        str(Nsrcs[i]),
-#        str(Ntimes[i]),
-#        str(Nfreqs[i]),
-#        str(Nbls[i]),
-#        str(beam[i])]
-#    sids_out.write(','.join(parms) + ',' + slurm_id + '\n')

--- a/scripts/do_batch_profiling.py
+++ b/scripts/do_batch_profiling.py
@@ -29,7 +29,8 @@ mem = '40G'
 time = '48:00:00'
 
 for n in Ncores:
-    cmd = ['./batch_profile_job.sh', Nsrcs, Ntimes, Nfreqs, Nbls, beam]
+    cmd = ['sbatch', '-n ' + str(n), '--cpus-per-task=1', '--mem=' + mem, '--time=' + time,
+           'batch_profile_job.sh', Nsrcs, Ntimes, Nfreqs, Nbls, beam]
     print(" ".join(cmd))
     results = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
     print(results)

--- a/scripts/profiling_plots.py
+++ b/scripts/profiling_plots.py
@@ -1,0 +1,84 @@
+#!/bin/env python
+
+# Make plots of profiling results under different constraints:
+
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib
+
+dat = np.genfromtxt(sys.argv[1], names=True, max_rows=2, delimiter=',')
+
+
+fields = ['JobID', 'Start', 'MaxRSS_GB', 'NNodes', 'NProcs', 'Nbls', 'Ntimes', 'Nchan', 'Nsrc', 'Beam', 'Ntasks', 'Runtime_Second']
+titles = [f.lower() for f in fields]
+fmts = ['U10', 'U10', 'f8', 'i4', 'i4', 'i4', 'i4', 'i4', 'i4', 'U10', 'i4', 'f8']
+dt = np.format_parser(fmts, dat.dtype.names, titles)
+
+dat = np.genfromtxt(sys.argv[1], autostrip=True, dtype=dt.dtype, delimiter=',', skip_header=1)
+
+Ncpus = np.unique(dat['NProcs'])
+beams = np.unique(dat['Beam'])
+Ntasks, inv, counts = np.unique(dat['Ntasks'], return_inverse=True, return_counts=True)
+NNodes = np.unique(dat['NNodes'])
+markers = ['.', 'o', '+', '<', '>', '*', 'v', '^', 'h', 'p']
+cmap = plt.get_cmap('tab10')
+colors = [cmap(i) for i in range(len(Ncpus))]
+
+
+params = ['Nbls', 'Ntimes', 'Nchan', 'Nsrc']
+fig1, axes = plt.subplots(nrows=1, ncols=len(beams))
+handles, labels = [], []
+ymin, ymax = np.min(dat['Runtime_Seconds']), np.max(dat['Runtime_Seconds'])
+ymax *= 1.20
+for nni in range(len(NNodes)):
+    condN = (dat['NNodes'] == NNodes[nni])
+    for bi in range(len(beams)):
+        condB = (dat['Beam'] == beams[bi])
+        for nc in range(len(Ncpus)):
+            inds = np.where(condN & condB & (dat['NProcs'] == Ncpus[nc]))
+            if len(inds[0]) == 0:
+                continue
+            axes[bi].scatter(dat['Ntasks'][inds], dat['Runtime_Seconds'][inds], label="{:d} cores, {:d} Nodes".format(Ncpus[nc], NNodes[nni]), color=colors[nc], marker=markers[nni])
+
+        axes[bi].set_title("{} beam".format(beams[bi]))
+        axes[bi].set_ylabel("Runtime (seconds)")
+        axes[bi].set_xlabel("Ntasks")
+        axes[bi].set_ylim([ymin, ymax])
+
+
+def f(m, c):
+    return plt.plot([], [], marker=m, color=c, ls="none")[0]
+
+
+colhandles = [f("s", colors[i]) for i in range(len(Ncpus))]
+markhandles = [f(markers[i], "k") for i in range(len(NNodes))]
+
+collabels = map('{:d} cpus'.format, Ncpus.tolist())
+marklabels = map('{:d} nodes'.format, NNodes.tolist())
+plt.figlegend(labels=collabels, handles=colhandles, loc='center right')
+leg2 = plt.figlegend(labels=marklabels, handles=markhandles, loc='lower right')
+plt.gca().add_artist(leg2)
+
+fig2, axes = plt.subplots(nrows=1, ncols=len(beams))
+ymin, ymax = np.min(dat['MaxRSS_GB']), np.max(dat['MaxRSS_GB'])
+ymax *= 1.20
+for nni in range(len(NNodes)):
+    condN = (dat['NNodes'] == NNodes[nni])
+    for bi in range(len(beams)):
+        condB = (dat['Beam'] == beams[bi])
+        for nc in range(len(Ncpus)):
+            inds = np.where(condN & condB & (dat['NProcs'] == Ncpus[nc]))
+            if len(inds[0]) == 0:
+                continue
+            axes[bi].scatter(dat['Ntasks'][inds], dat['MaxRSS_GB'][inds], label="{:d} cores, {:d} Nodes".format(Ncpus[nc], NNodes[nni]), color=colors[nc], marker=markers[nni])
+
+        axes[bi].set_title("{} beam".format(beams[bi]))
+        axes[bi].set_ylabel("MaxRSS (GB)")
+        axes[bi].set_xlabel("Ntasks")
+        axes[bi].set_ylim([ymin, ymax])
+plt.figlegend(labels=collabels, handles=colhandles, loc='center right')
+leg2 = plt.figlegend(labels=marklabels, handles=markhandles, loc='lower right')
+plt.gca().add_artist(leg2)
+
+plt.show()

--- a/scripts/test_cover_noinstall.sh
+++ b/scripts/test_cover_noinstall.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR/..
+
+cd pyuvsim/tests
+nosetests --nologcapture --with-coverage --cover-erase --cover-package=pyuvsim --cover-html "$@"


### PR DESCRIPTION
Core code update:
Removes the profiling decorators and lets users select functions by name for line by line runtime profiling. There is a default list of functions to profile. Front-end support is limited, though --- the user needs to run `profiling.set_profiler` to use it. I can potentially add some kind of profiling yaml support to simsetup, but it's not required at this point.

Script updates:
The `run_profile_pyuvsim.py` wrapper provides a convenient tool for running a basic job with specified numbers of times/sources/baselines/sources/frequencies and profiling the run. The `do_batch_profiling.py` script launches a set of SLURM jobs with different numbers of PUs and tasks and neatly summarizes the run results in a csv file, labelled for the branch. The `profiling_plots.py` script can load and plot based on this file.

A key difference in the wrappers: Originally, I was launching thousands of SLURM jobs at a time, which was ugly and rude to other CCV users. These wrappers run full sets of profiling jobs within a single SLURM task, reducing overhead and keeping things neater. Memory and runtime per configuration are measured using python's `psutils` and bash timing respectively, instead of using SLURM's `sacct` tool. I'll have to check that `psutils.memory_info()` accurately finds the peak RSS across MPI ranks, but it does seem to give reasonable results for memory usage.