### PR TITLE
 Add support for selecting baselines to simulate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
   - source activate test-environment
   - conda install astropy pyyaml mpi4py line_profiler
   - conda install -c conda-forge pycodestyle coveralls
-  - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
+  - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git@select_metadata
   - python setup.py install
   - python -c "from pyuvdata import version; version.main()"
   - conda list

--- a/docs/parameter_files.rst
+++ b/docs/parameter_files.rst
@@ -8,7 +8,7 @@ The outermost parameter file is the `obsparam_*.yaml`, which is parsed by ``init
 
 The antenna layout and telescope config yaml files determine the full properties of the array, including location, beam models, layout, and naming.
 
-The catalog text files give point source lists. 
+The catalog text files give point source lists.
 
 
 These files contain overall simulation parameters.
@@ -25,7 +25,7 @@ Passed into ``run_param_pyuvsim.py``
       channel_width: 80000.0    # Frequency channel width
       end_freq: 100800000.0     # Start and end frequencies (Hz)
       start_freq: 100000000.0
-      freq_array : [1.0000e+08,   1.0008e+08,   1.0016e+08, 1.0024e+08, 
+      freq_array : [1.0000e+08,   1.0008e+08,   1.0016e+08, 1.0024e+08,
           1.0032e+08,   1.0040e+08,   1.0048e+08, 1.0056e+08,
           1.0064e+08, 1.0072e+08]
       bandwidth: 800000.0
@@ -39,8 +39,12 @@ Passed into ``run_param_pyuvsim.py``
       Ntimes: 10        # Number of times.
       integration_time: 11.0  # Time step size  (seconds)
       start_time: 2457458.1738949567    # Start and end times (Julian date)
-      end_time: 2457458.175168105  
+      end_time: 2457458.175168105
       duration_hours: 0.0276
+    select: # any keyword parameters that UVData.select can accept, except polarizations
+      bls: [(1, 2), (3, 4), (5, 6)]
+      ant_str: 'cross'
+      antenna_nums: [1, 7, 9, 15]
 
 **Note** The example above is shown with all allowed keywords, but many of these are redundant. This will be further explained below.
 
@@ -49,41 +53,41 @@ Time and frequency
 ^^^^^^^^^^^^^^^^^^
 
     Time and frequency structure may be defined with different combinations of keywords to suit the user's purposes. The user must specify sufficient information for the frequency and time arrays to be defined.
-    
+
     Minimum frequency requirements:
         specify bandwidth via one of the following combinations:
             * (``start_freq``, ``end_freq``)
             * (``channel_width``, ``Nfreqs``)
             * (``bandwidth``)
-    
+
         specify channel width via:
             * (``bandwidth``, ``Nfreqs``)
             * (``channel width``)
-    
+
         specify a reference frequency via:
             * (``start_freq``)
             * (``end_freq``)
-    
+
     As long as one of the sets from each category above is met by the supplied keywords, the frequency array will be successfully built.
     Likewise for the time array:
-    
+
     Minimum time requirements:
         Total time:
             * (``start_time``, ``end_time``)
             * (``integration_time``, ``Ntimes``)
             * (``duration_hours``) or (``duration_days``)
-    
+
         Time step:
             * (``duration_hours`` or ``duration_days``, ``Ntimes``)
             * (``integration_time``)
-    
+
         Reference time:
             * (``start_time``)
             * (``end_time``)
-    
+
     You can also just give an explicit ``time_array`` or ``freq_array``.
 
-    
+
 Telescope Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -108,23 +112,25 @@ Telescope Configuration
 Sources
 ^^^^^^^
     Specify the path to a text catalog file via ``catalog``.
-    
+
     An example catalog file:
 
     .. literalinclude:: ../pyuvsim/data/mock_catalog_heratext_2458098.27471265.txt
         :end-before: 3
-   
+
     The columns are:
         * ``SOURCE_ID`` : Identifier for the source
         * ``RA_J2000`` : Right ascension of source at J2000 epoch, in decimal degrees.
         * ``DEC_J2000`` : Declination of source at J2000 epoch, in decimal degrees.
         * ``FLUX``: Source stokes I brightness in Janskies.  (Currently only point sources are supported).
-        * ``Frequency``: A reference frequency for the given flux. This will be used for spectral modeling. 
-    
+        * ``Frequency``: A reference frequency for the given flux. This will be used for spectral modeling.
+
     Alternatively, you can specify a ``mock`` and provide the ``mock_arrangement`` keyword to specify which mock catalog to generate. Available options are shown in the ``create_mock_catalog`` docstring:
 
     .. module:: pyuvsim
 
     .. autofunction:: create_mock_catalog
 
-
+Select
+^^^^^^
+    Specify keywords to select which baselines to simulate. The selection is done by UVData.select, so it can accept any keyword that function accepts, except ones that affect polarization because pyuvsim computes all polarizations.

--- a/pyuvsim/data/test_config/obsparam_mwa_nocore.yaml
+++ b/pyuvsim/data/test_config/obsparam_mwa_nocore.yaml
@@ -1,0 +1,18 @@
+filing:
+  outdir: '.'
+  outfile_name: 'sim_results.uvfits'
+freq:
+  Nfreqs: 10
+  bandwidth: 800000.0
+  start_freq: 100000000.0
+sources:
+  catalog: 'mock'
+  mock_arrangement: 'zenith'
+telescope:
+  array_layout: '../mwa_nocore_layout.csv'
+  telescope_config_name: '../mwa128_config.yaml'
+time:
+  Ntimes: 10
+  duration_days: 0.001145833
+  integration_time: 11.0
+  start_time: 2457458.1738949567

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -542,11 +542,12 @@ def initialize_uvdata_from_params(obs_params):
     uv_obj.ant_1_array, uv_obj.ant_2_array = \
         uv_obj.baseline_to_antnums(uv_obj.baseline_array)
 
-    # add other required metadata to allow select on metadata to work
+    # add other required metadata to allow select to work without errors
+    # these will all be overwritten in uvsim.init_uvdata_out, so it's ok to hardcode them here
     uv_obj.polarization_array = np.array([-5, -6, -7, -8])
     uv_obj.set_lsts_from_time_array()
     uv_obj.set_uvws_from_antenna_positions()
-    uv_obj.history = ''  # this will get overwritten in uvsim.init_uvdata_out
+    uv_obj.history = ''
 
     # down select baselines (or anything that can be passed to pyuvdata's select method)
     # Note: cannot down select polarizations (including via ant_str or bls keywords)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -274,6 +274,7 @@ def init_uvdata_out(uv_in, source_list_name, uvdata_file=None,
 
     uv_obj.set_drift()
     uv_obj.vis_units = 'Jy'
+    uv_obj.polarization_array = np.array([-5, -6, -7, -8])
     uv_obj.instrument = uv_obj.telescope_name
     uv_obj.set_lsts_from_time_array()
     uv_obj.spw_array = np.array([0])
@@ -281,6 +282,7 @@ def init_uvdata_out(uv_in, source_list_name, uvdata_file=None,
         uv_obj.channel_width = 1.  # Hz
     else:
         uv_obj.channel_width = np.diff(uv_obj.freq_array[0])[0]
+    uv_obj.set_uvws_from_antenna_positions()
     if uv_obj.Ntimes == 1:
         uv_obj.integration_time = np.ones_like(uv_obj.time_array, dtype=np.float64)  # Second
     else:

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -274,7 +274,6 @@ def init_uvdata_out(uv_in, source_list_name, uvdata_file=None,
 
     uv_obj.set_drift()
     uv_obj.vis_units = 'Jy'
-    uv_obj.polarization_array = np.array([-5, -6, -7, -8])
     uv_obj.instrument = uv_obj.telescope_name
     uv_obj.set_lsts_from_time_array()
     uv_obj.spw_array = np.array([0])
@@ -282,7 +281,6 @@ def init_uvdata_out(uv_in, source_list_name, uvdata_file=None,
         uv_obj.channel_width = 1.  # Hz
     else:
         uv_obj.channel_width = np.diff(uv_obj.freq_array[0])[0]
-    uv_obj.set_uvws_from_antenna_positions()
     if uv_obj.Ntimes == 1:
         uv_obj.integration_time = np.ones_like(uv_obj.time_array, dtype=np.float64)  # Second
     else:


### PR DESCRIPTION
currently requires the `select_metadata` branch of pyuvdata. That Travis line should be reverted when that branch is merged into pyuvdata's master

fixes #59 
fixes #62