### PR TITLE
MPI-3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ install:
   - conda info -a
 
   # install dependencies
-  - conda install numpy scipy astropy six nose pip pyyaml mpi4py line_profiler pycodestyle coveralls
+  - conda install numpy scipy astropy six nose pip pyyaml line_profiler pycodestyle coveralls
+  - conda install -c conda-forge mpi4py
   - pip install git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
   - python setup.py install
   - python -c "from pyuvdata import version; version.main()"

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -29,6 +29,10 @@ singlesource_vot = os.path.join(SIM_DATA_PATH, 'single_source.vot')
 singlesource_txt = os.path.join(SIM_DATA_PATH, 'single_source.txt')
 
 
+def test_mpi_version():
+    nt.assert_true(MPI.VERSION == 3)
+
+
 def test_run_uvsim():
     hera_uv = UVData()
     hera_uv.read_uvfits(EW_uvfits_file)


### PR DESCRIPTION
Enables MPI3 functionality in mpi4py by installing from conda-forge in travis. Checks that MPI3 is installed in the tests.

Not a high priority, but this will be necessary if we decide to use shared memory. Either way, this ensures we're using the latest version of mpi.