### PR TITLE
Fix pyuvdata error

### DIFF
--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -893,7 +893,7 @@ def uvdata_to_telescope_config(uvdata_in, beam_filepath, layout_csv_name=None,
         layout_csv_path = check_file_exists_and_increment(os.path.join(path_out, uvdata_in.telescope_name + "_layout.csv"))
         layout_csv_name = os.path.basename(layout_csv_path)
 
-    antpos_enu, antenna_numbers = uvdata_in.get_ENU_antpos(center=False)
+    antpos_enu, antenna_numbers = uvdata_in.get_ENU_antpos()
 
     e, n, u = antpos_enu.T
     beam_ids = np.zeros_like(e).astype(int)

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -83,8 +83,8 @@ def test_run_param_uvsim():
     param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testvot.yaml')
 
     uvtest.checkWarnings(pyuvsim.uvsim.run_uvsim, [param_filename],
-                         nwarnings=10,
-                         category=astropy.io.votable.exceptions.W50)
+                         nwarnings=11,
+                         category=[astropy.io.votable.exceptions.W50] * 10 + [DeprecationWarning])
 
     uv_new_vot = UVData()
     uvtest.checkWarnings(uv_new_vot.read_uvfits, [tempfilename], message='antenna_diameters is not set')

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -347,11 +347,14 @@ def test_uvfits_to_config():
     # Read uvfits file to params.
     uv0 = UVData()
     uv0.read_uvfits(longbl_uvfits_file)
+    warningmessages = ['The default for the `center` keyword has changed. Previously it defaulted to True, using the median antennna location; now it defaults to False, using the telescope_location.',
+                       'The xyz array in ENU_from_ECEF is being interpreted as (Npts, 3). Historically this function has supported (3, Npts) arrays, please verify that array ordering is as expected.']
     path, telescope_config, layout_fname = \
         uvtest.checkWarnings(pyuvsim.simsetup.uvdata_to_telescope_config,
                              [uv0, herabeam_default], dict(path_out=opath, return_names=True),
-                             category=PendingDeprecationWarning,
-                             message='The enu array in ECEF_from_ENU is being interpreted as (Npts, 3)')
+                             nwarnings=2,
+                             category=[DeprecationWarning, PendingDeprecationWarning],
+                             message=warningmessages)
     uv0.integration_time[-1] += 2  # Test case of non-uniform integration times
     uvtest.checkWarnings(pyuvsim.simsetup.uvdata_to_config_file, [uv0], dict(
         telescope_config_name=os.path.join(path, telescope_config),
@@ -373,7 +376,9 @@ def test_uvfits_to_config():
                              dict(telescope_config_name=telescope_config,
                                   layout_csv_name=layout_fname,
                                   path_out=opath, return_names=True),
-                             category=PendingDeprecationWarning)
+                             category=[DeprecationWarning, PendingDeprecationWarning],
+                             nwarnings=2,
+                             message=warningmessages)
     pyuvsim.simsetup.uvdata_to_config_file(uv1, param_filename=second_param_filename,
                                            telescope_config_name=os.path.join(path, telescope_config),
                                            layout_csv_name=os.path.join(path, layout_fname),

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -371,8 +371,8 @@ def test_offzenith_source_multibl_uvfits():
 
     # get antennas positions into ENU
     antpos, ants = uvtest.checkWarnings(hera_uv.get_ENU_antpos,
-                                        message='The xyz array in ENU_from_ECEF is being interpreted as (Npts, 3)',
-                                        category=PendingDeprecationWarning)
+                                        category=[DeprecationWarning, PendingDeprecationWarning],
+                                        nwarnings=2)
     antenna1 = pyuvsim.Antenna('ant1', ants[0], np.array(antpos[0, :]), 0)
     antenna2 = pyuvsim.Antenna('ant2', ants[1], np.array(antpos[1, :]), 0)
     antenna3 = pyuvsim.Antenna('ant3', ants[2], np.array(antpos[2, :]), 0)
@@ -457,7 +457,8 @@ def test_file_to_tasks():
     Ntasks = Nblts * Nfreqs * Nsrcs
     beam_dict = None
 
-    uvtask_list = list(pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), hera_uv, sources, beam_list, beam_dict))
+    taskiter = pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), hera_uv, sources, beam_list, beam_dict)
+    uvtask_list = uvtest.checkWarnings(list, [taskiter], category=DeprecationWarning)
 
     tlist = copy.deepcopy(uvtask_list)
 
@@ -579,7 +580,8 @@ def test_gather():
     Ntasks = Nblts * Nfreqs * Nsrcs
     beam_dict = dict(zip(hera_uv.antenna_names, [0] * hera_uv.Nants_data))
 
-    uvtask_list = list(pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), hera_uv, sources, beam_list, beam_dict))
+    taskiter = pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), hera_uv, sources, beam_list, beam_dict)
+    uvtask_list = uvtest.checkWarnings(list, [taskiter], category=DeprecationWarning)
 
     uv_out = pyuvsim.init_uvdata_out(hera_uv, 'zenith_source',
                                      obs_param_file='', telescope_config_file='', antenna_location_file='')
@@ -618,7 +620,8 @@ def test_local_task_gen():
     beam_dict = None
 
     # Copy sources and beams so we don't accidentally reuse quantities.
-    uvtask_list = list(pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), hera_uv, sources, beam_list, beam_dict))
+    taskiter = pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), hera_uv, sources, beam_list, beam_dict)
+    uvtask_list = uvtest.checkWarnings(list, [taskiter], category=DeprecationWarning)
     uvtask_iter = pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), hera_uv, copy.deepcopy(sources), copy.deepcopy(beam_list), beam_dict)
 
     # Check error conditions

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -165,7 +165,7 @@ def uvdata_to_task_iter(task_ids, input_uv, catalog, beam_list, beam_dict):
     # There will always be relatively few antennas, so just build the full list.
     antenna_names = input_uv.antenna_names
     antennas = []
-    antpos_enu, antnums = input_uv.get_ENU_antpos(center=False)
+    antpos_enu, antnums = input_uv.get_ENU_antpos()
     for num, antname in enumerate(antenna_names):
         if beam_dict is None:
             beam_id = 0


### PR DESCRIPTION
The new default for the ``center`` keyword in get_ENU_antpos caused some tests to fail (warning catchers, in particular). This fixes that.