### PR TITLE
Chromatic gaussian beam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## [Unreleased]
 
 ### Added
-- Checking the beam kernel width makes sense for Airy beams
 - Enabled Gaussian beams to be defined from antenna diameter and have chromaticity
+- Checking the beam kernel width makes sense for Airy beams
 
 ### Changed
 - Pending deprecation of gaussian beams defined from sigma parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Added
 - Checking the beam kernel width makes sense for Airy beams
+- Enabled Gaussian beams to be defined from antenna diameter and have chromaticity
 
+### Changed
+- Pending deprecation of gaussian beams defined from sigma parameter
 
 ## [0.2.3] - 2019-2-17
 

--- a/docs/parameter_files.rst
+++ b/docs/parameter_files.rst
@@ -114,7 +114,7 @@ Telescope Configuration
     Analytic beams may require additional parameters.
 
     - uniform = The same response in all directions. No additional parameters.
-    - gaussian = Gaussian function shaped beam. Requires either an antenna diameter (in meters) or a standard deviation sigma (in radians).
+    - gaussian = Gaussian function shaped beam. Requires either an antenna diameter (in meters) or a standard deviation sigma (in radians). This standard deviation sets the width of the beam in zenith angle.
     - airy = Airy disk (ie, diffraction pattern of a circular aperture). Requires an antenna diameter.
 
     These extra keywords should be included after the beam dictionary in the telescope config file. Note that beams defined with an antenna diameter will be chromatic. That is, their widths on the sky will change with frequency.

--- a/docs/parameter_files.rst
+++ b/docs/parameter_files.rst
@@ -114,7 +114,7 @@ Telescope Configuration
     Analytic beams may require additional parameters.
 
     - uniform = The same response in all directions. No additional parameters.
-    - gaussian = Gaussian function shaped beam. Requires either an antenna diameter (in meters) or a standard deviation sigma (in radians). This standard deviation sets the width of the beam in zenith angle.
+    - gaussian = Gaussian function shaped beam. Requires either an antenna diameter (in meters) or a standard deviation sigma (in radians). This standard deviation sets the width of the beam in zenith angle. Note that defining gaussian beams via `sigma` will be deprecated in the future.
     - airy = Airy disk (ie, diffraction pattern of a circular aperture). Requires an antenna diameter.
 
     These extra keywords should be included after the beam dictionary in the telescope config file. Note that beams defined with an antenna diameter will be chromatic. That is, their widths on the sky will change with frequency.

--- a/docs/parameter_files.rst
+++ b/docs/parameter_files.rst
@@ -111,6 +111,14 @@ Telescope Configuration
 
     This yaml file provides the telescope name, location in latitude/longitude/altitude in degrees/degrees/meters (respectively), and the `beam dictionary`. In this case, beam_id == 0 is the UVBeam file written out to hera.uvbeam, and beam_id == 1 is an Airy beam with diameter 16m. The dictionary only needs to be as long as the number of unique beams used in the array, while the layout file specifies which antennas will use which beam type. This allows for a mixture of beams to be used, as in this example.
 
+    Analytic beams may require additional parameters.
+
+    - uniform = The same response in all directions. No additional parameters.
+    - gaussian = Gaussian function shaped beam. Requires either an antenna diameter (in meters) or a standard deviation sigma (in radians).
+    - airy = Airy disk (ie, diffraction pattern of a circular aperture). Requires an antenna diameter.
+
+    These extra keywords should be included after the beam dictionary in the telescope config file. Note that beams defined with an antenna diameter will be chromatic. That is, their widths on the sky will change with frequency.
+
     The figure below shows the array created by these configurations, with beam type indicated by color.
 
     .. image:: baseline_lite.png

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -15,9 +15,6 @@ def diameter_to_sigma(diam, freqs):
     an Airy disk's main lobe for a given diameter.
     """
 
-    if not isinstance(freqs, np.ndarray):
-        freqs = np.array([freqs]).dtype(np.float)
-
     c_ms = 299792458.
     wavelengths = c_ms / freqs
 

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -95,8 +95,8 @@ class AnalyticBeam(object):
             # standard deviation of sigma is referring to the standard deviation of e-field beam!
             # copy along freq. axis
             if self.diameter is not None:
-                sigmas = diameter_to_sigma(diameter, freq_array)
-                values = np.exp(-(za_array[np.newaxis, ...]**2) / (2 * sigma[:, np.newaxis]**2))
+                sigmas = diameter_to_sigma(self.diameter, freq_array)
+                values = np.exp(-(za_array[np.newaxis, ...]**2) / (2 * sigmas[:, np.newaxis]**2))
             elif self.sigma is not None:
                 values = np.exp(-(za_array**2) / (2 * self.sigma**2))
                 values = np.broadcast_to(values, (freq_array.size, az_array.size))

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -21,7 +21,7 @@ def diameter_to_sigma(diam, freqs):
     c_ms = 299792458.
     wavelengths = c_ms / freqs
 
-    scalar = 1.616339948        # Found by fitting a Gaussian to an Airy disk function
+    scalar = 2.2150894        # Found by fitting a Gaussian to an Airy disk function
 
     sigma = np.arcsin(scalar * wavelengths / (np.pi * diam)) * 2 / 2.355
 

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -13,6 +13,14 @@ def diameter_to_sigma(diam, freqs):
     """
     Find the stddev of a gaussian with fwhm equal to that of
     an Airy disk's main lobe for a given diameter.
+
+    Args:
+        diam: Antenna diameter in meters
+        freqs: Array of frequencies, in Hz
+    Returns:
+        sigma: The standard deviation in zenith angle radians for a Gaussian beam
+               with FWHM equal to that of an Airy disk's main lobe for an aperture
+               with the given diameter.
     """
 
     c_ms = 299792458.

--- a/pyuvsim/data/test_config/28m_triangle_10time_10chan_gaussnoshape.yaml
+++ b/pyuvsim/data/test_config/28m_triangle_10time_10chan_gaussnoshape.yaml
@@ -1,0 +1,7 @@
+beam_paths:
+  0: HERA_NicCST.uvbeam
+  1: 'uniform'
+  2: 'gaussian'
+  3: 'gaussian'
+telescope_location: (-30.721527777777847, 21.428305555555557, 1073.0000000046566)
+telescope_name: HERA

--- a/pyuvsim/data/test_config/28m_triangle_10time_10chan_sigmaonly.yaml
+++ b/pyuvsim/data/test_config/28m_triangle_10time_10chan_sigmaonly.yaml
@@ -1,0 +1,8 @@
+beam_paths:
+  0: HERA_NicCST.uvbeam
+  1: 'uniform'
+  2: 'gaussian'
+  3: 'gaussian'
+sigma: 0.02
+telescope_location: (-30.721527777777847, 21.428305555555557, 1073.0000000046566)
+telescope_name: HERA

--- a/pyuvsim/data/test_config/param_10time_10chan_2.yaml
+++ b/pyuvsim/data/test_config/param_10time_10chan_2.yaml
@@ -10,7 +10,7 @@ sources:
   mock_arrangement: 'zenith'
 telescope:
   array_layout: 'triangle_bl_layout.csv'
-  telescope_config_name: '28m_triangle_10time_10chan.yaml'
+  telescope_config_name: '28m_triangle_10time_10chan_sigmaonly.yaml'
 time:
   Ntimes: 10
   duration_days: 0.001145833

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1010,10 +1010,8 @@ def beam_string_to_object(beam_model):
 
         _, model, par, val = beam_model.split('_')
         if par == 'sig':
-            print(model)
             return AnalyticBeam(model, sigma=float(val))
         if par == 'diam':
-            print(model)
             return AnalyticBeam(model, diameter=float(val))
 
     path = beam_model   # beam_model = path to beamfits

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -546,20 +546,22 @@ def parse_telescope_params(tele_params, config_path):
         if beam_model in AnalyticBeam.supported_types:
             # Gaussian beam requires either diameter or sigma
             # Airy beam requires diameter
+            if beam_model == 'uniform':
+                beam_model = 'analytic_uniform'
             if beam_model == 'gaussian':
                 try:
                     diam = telconfig['diameter']
-                    beam_model = '_'.join([beam_model, 'diam', str(diam)])
+                    beam_model = '_'.join(['analytic', beam_model, 'diam', str(diam)])
                 except KeyError:
                     try:
                         sigma = telconfig['sigma']
-                        beam_model = '_'.join([beam_model, 'sig', str(sigma)])
+                        beam_model = '_'.join(['analytic', beam_model, 'sig', str(sigma)])
                     except KeyError:
                         raise KeyError("Missing shape parameter for gaussian beam (diameter or sigma).")
             if beam_model == 'airy':
                 try:
                     diam = telconfig['diameter']
-                    beam_model = beam_model + '_' + str(diam)
+                    beam_model = '_'.join(['analytic', beam_model, 'diam', str(diam)])
                 except KeyError:
                     raise KeyError("Missing diameter for airy beam.")
         else:
@@ -1002,15 +1004,17 @@ def beam_string_to_object(beam_model):
         Make a beam object given an identifying string.
     """
     # Identify analytic beams
+    if beam_model.startswith('analytic'):
+        if beam_model.startswith('analytic_uniform'):
+            return AnalyticBeam('uniform')
 
-    if beam_model.startswith('uniform'):
-        return AnalyticBeam(beam_model)
-
-    model, par, val = beam_model.split('_')
-    if par == 'sig':
-        return AnalyticBeam(beam_model, sigma=float(val))
-    if par == 'diam':
-        return AnalyticBeam(beam_model, diameter=float(val))
+        _, model, par, val = beam_model.split('_')
+        if par == 'sig':
+            print(model)
+            return AnalyticBeam(model, sigma=float(val))
+        if par == 'diam':
+            print(model)
+            return AnalyticBeam(model, diameter=float(val))
 
     path = beam_model   # beam_model = path to beamfits
     uvb = UVBeam()

--- a/pyuvsim/tests/test_analyticbeam.py
+++ b/pyuvsim/tests/test_analyticbeam.py
@@ -154,7 +154,7 @@ def test_uv_beam_widths():
         nt.assert_true(np.isclose(diameter_m / lams[i], kern_radius, rtol=0.5))
 
 
-def test_gaussian_beam():
+def test_achromatic_gaussian_beam():
     sigma_rad = Angle('5d').to('rad').value
     beam = pyuvsim.AnalyticBeam('gaussian', sigma=sigma_rad)
     beam.peak_normalize()

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -165,8 +165,8 @@ def check_param_reader(config_num):
 
         params_bad['config_path'] = os.path.join(SIM_DATA_PATH, "test_config")
 
-        params_bad['telescope']['telescope_config_name'] = os.path.join(SIM_DATA_PATH, 'test_config', '28m_triangle_10time_10chan_nosigma.yaml')
-        nt.assert_raises(KeyError, pyuvsim.initialize_uvdata_from_params, params_bad)
+        #params_bad['telescope']['telescope_config_name'] = os.path.join(SIM_DATA_PATH, 'test_config', '28m_triangle_10time_10chan_nosigma.yaml')
+        #nt.assert_raises(KeyError, pyuvsim.initialize_uvdata_from_params, params_bad)
         params_bad['telescope']['telescope_config_name'] = os.path.join(SIM_DATA_PATH, 'test_config', '28m_triangle_10time_10chan_nodiameter.yaml')
         nt.assert_raises(KeyError, pyuvsim.initialize_uvdata_from_params, params_bad)
         params_bad['telescope']['telescope_config_name'] = os.path.join(SIM_DATA_PATH, 'test_config', '28m_triangle_10time_10chan_nofile.yaml')

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -165,8 +165,6 @@ def check_param_reader(config_num):
 
         params_bad['config_path'] = os.path.join(SIM_DATA_PATH, "test_config")
 
-        #params_bad['telescope']['telescope_config_name'] = os.path.join(SIM_DATA_PATH, 'test_config', '28m_triangle_10time_10chan_nosigma.yaml')
-        #nt.assert_raises(KeyError, pyuvsim.initialize_uvdata_from_params, params_bad)
         params_bad['telescope']['telescope_config_name'] = os.path.join(SIM_DATA_PATH, 'test_config', '28m_triangle_10time_10chan_nodiameter.yaml')
         nt.assert_raises(KeyError, pyuvsim.initialize_uvdata_from_params, params_bad)
         params_bad['telescope']['telescope_config_name'] = os.path.join(SIM_DATA_PATH, 'test_config', '28m_triangle_10time_10chan_nofile.yaml')
@@ -456,7 +454,7 @@ def test_horizon_cut():
             nt.assert_true(src.name in selected_source_names)
 
     # Now check that I get the same visibilities simulating with and without the horizon cut.
-    beam_list = ['uniform']  # Simplify with a single uniform beam model
+    beam_list = ['analytic_uniform']  # Simplify with a single uniform beam model
     kwds = dict(source_list_name='random', obs_param_file='', telescope_config_file='', antenna_location_file='')
     kwds['catalog'] = cut_sourcelist
     uv_select = uvtest.checkWarnings(pyuvsim.run_uvdata_uvsim, [uv_in, beam_list], kwds, category=DeprecationWarning)

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -165,6 +165,8 @@ def check_param_reader(config_num):
 
         params_bad['config_path'] = os.path.join(SIM_DATA_PATH, "test_config")
 
+        params_bad['telescope']['telescope_config_name'] = os.path.join(SIM_DATA_PATH, 'test_config', '28m_triangle_10time_10chan_gaussnoshape.yaml')
+        nt.assert_raises(KeyError, pyuvsim.initialize_uvdata_from_params, params_bad)
         params_bad['telescope']['telescope_config_name'] = os.path.join(SIM_DATA_PATH, 'test_config', '28m_triangle_10time_10chan_nodiameter.yaml')
         nt.assert_raises(KeyError, pyuvsim.initialize_uvdata_from_params, params_bad)
         params_bad['telescope']['telescope_config_name'] = os.path.join(SIM_DATA_PATH, 'test_config', '28m_triangle_10time_10chan_nofile.yaml')


### PR DESCRIPTION
- Enables Gaussian beams to be defined with an antenna diameter, such that its FWHM is equal to that of an Airy disk for the same antenna diameter.
- Begins deprecating Gaussian beams defined with "sigma".

Fixes #144 