### PR TITLE
Remove middle initials from pyuvdata citation.

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -51,7 +51,7 @@
 	number = {10},
 	urldate = {2018-01-27},
 	journal = {The Journal of Open Source Software},
-	author = {J. {Hazelton}, {Bryna} and C. {Jacobs}, {Daniel} and C. {Pober}, {Jonathan} and P. {Beardsley}, {Adam}},
+	author = {{Hazelton}, {Bryna} and {Jacobs}, {Daniel} and {Pober}, {Jonathan} and {Beardsley}, {Adam}},
 	month = feb,
 	year = {2017},
 	pages = {140},


### PR DESCRIPTION
In the JOSS paper, the `pyuvdata` citation includes middle initials but not first initials. This fix removes the middle initials, so the citation is just last names (like all the other inline citations).