### PR TITLE
Support spectral gaussian and power beams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- Option to convert analytic beams from efield to pstokes
+- Enabled Gaussian beams to be defined with power law widths.
 - Enabled Gaussian beams to be defined from antenna diameter and have chromaticity
 - Checking the beam kernel width makes sense for Airy beams
 

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -168,7 +168,8 @@ class AnalyticBeam(object):
             raise ValueError('no interp for this type: ', self.type)
 
         if self.beam_type == 'power':
-            interp_data = interp_data**2
+            # Cross multiply feeds.
+            interp_data = interp_data[0] * interp_data[1]
 
         return interp_data, interp_basis_vector
 

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -44,11 +44,32 @@ class AnalyticBeam(object):
 
     Supports uniform (unit response in all directions), gaussian, and Airy
     function beam types.
+
+    Supported types:
+        Uniform beam : Unit response from all directions.
+        Airy: An Airy disk pattern (the 2D Fourier transform of a circular aperture of width given by `diameter`)
+        Gaussian : A peak-normalized gaussian function.
+                   If given a `diameter`, then this makes a chromatic beam with FWHMs matching an equivalent Airy disk beam at each frequency.
+                   If given a `sigma`, this makes an achromatic beam with standard deviation set to `sigma`
+                   If given a `sigma`, `ref_freq`, and `spectral_index`, then this will make a chromatic beam
+                        with standard deviation defined by a power law:
+                            stddev(f) = sigma * (f/ref_freq)**(spectral_index)
+
+    Args:
+        type: (string)
+            Beam type to use
+        sigma: (float)
+            standard deviation [radians] for gaussian beam
+            When spectral index is set, this represents the FWHM at the ref_freq.
+        spectral_index : (float, optional)
+            Scale gaussian beam width as a power law with frequency.
+        ref_freq : (float, optional)
+            If set, this sets the reference frequency for the beam width power law.
     """
 
     supported_types = ['uniform', 'gaussian', 'airy']
 
-    def __init__(self, type, sigma=None, diameter=None):
+    def __init__(self, type, sigma=None, diameter=None, spectral_index=0.0, ref_freq=None):
         if type in self.supported_types:
             self.type = type
         else:
@@ -59,6 +80,10 @@ class AnalyticBeam(object):
             warnings.warn("Achromatic gaussian beams will not be supported in the future."
                           + "Define your gaussian beam by a dish diameter from now on.", PendingDeprecationWarning)
 
+        if (not spectral_index == 0.0) and (ref_freq is None):
+            raise ValueError("ref_freq must be set for nonzero gaussian beam spectral index")
+        elif ref_freq is None:
+            self.ref_freq = 1.0
         self.diameter = diameter
         self.data_normalization = 'peak'
         self.freq_interp_kind = 'linear'
@@ -114,10 +139,9 @@ class AnalyticBeam(object):
             # copy along freq. axis
             if self.diameter is not None:
                 sigmas = diameter_to_sigma(self.diameter, freq_array)
-                values = np.exp(-(za_array[np.newaxis, ...]**2) / (2 * sigmas[:, np.newaxis]**2))
             elif self.sigma is not None:
-                values = np.exp(-(za_array**2) / (2 * self.sigma**2))
-                values = np.broadcast_to(values, (freq_array.size, az_array.size))
+                sigmas = self.sigma * (freq_array / self.ref_freq)**(self.spectral_index)
+            values = np.exp(-(za_array[np.newaxis, ...]**2) / (2 * sigmas[:, np.newaxis]**2))
             interp_data[1, 0, 0, :, :] = values
             interp_data[0, 0, 1, :, :] = values
             interp_data[1, 0, 1, :, :] = values

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -8,6 +8,8 @@ import numpy as np
 import warnings
 from scipy.special import j1
 
+import pyuvdata.utils as uvutils
+
 
 def diameter_to_sigma(diam, freqs):
     """
@@ -60,9 +62,19 @@ class AnalyticBeam(object):
         self.diameter = diameter
         self.data_normalization = 'peak'
         self.freq_interp_kind = 'linear'
+        self.beam_type = 'efield'
 
     def peak_normalize(self):
         pass
+
+    def efield_to_pstokes(self):
+        """
+        Tell interp to return values corresponding with a pstokes power beam.
+        """
+        self.beam_type = 'power'
+        pol_strings = ['pI', 'pQ', 'pU', 'pV']
+        self.polarization_array = np.array([uvutils.polstr2num(ps.upper()) for ps in pol_strings])
+
 
     def interp(self, az_array, za_array, freq_array, reuse_spline=None):
         """
@@ -129,6 +141,9 @@ class AnalyticBeam(object):
             interp_basis_vector = None
         else:
             raise ValueError('no interp for this type: ', self.type)
+
+        if self.beam_type == 'power':
+            interp_data = interp_data**2
 
         return interp_data, interp_basis_vector
 

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -80,7 +80,7 @@ class AnalyticBeam(object):
             warnings.warn("Achromatic gaussian beams will not be supported in the future."
                           + "Define your gaussian beam by a dish diameter from now on.", PendingDeprecationWarning)
 
-        if (not spectral_index == 0.0) and (ref_freq is None):
+        if (spectral_index != 0.0) and (ref_freq is None):
             raise ValueError("ref_freq must be set for nonzero gaussian beam spectral index")
         elif ref_freq is None:
             ref_freq = 1.0

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -83,7 +83,9 @@ class AnalyticBeam(object):
         if (not spectral_index == 0.0) and (ref_freq is None):
             raise ValueError("ref_freq must be set for nonzero gaussian beam spectral index")
         elif ref_freq is None:
-            self.ref_freq = 1.0
+            ref_freq = 1.0
+        self.ref_freq = ref_freq
+        self.spectral_index = spectral_index
         self.diameter = diameter
         self.data_normalization = 'peak'
         self.freq_interp_kind = 'linear'
@@ -99,7 +101,6 @@ class AnalyticBeam(object):
         self.beam_type = 'power'
         pol_strings = ['pI', 'pQ', 'pU', 'pV']
         self.polarization_array = np.array([uvutils.polstr2num(ps.upper()) for ps in pol_strings])
-
 
     def interp(self, az_array, za_array, freq_array, reuse_spline=None):
         """

--- a/pyuvsim/tests/test_analyticbeam.py
+++ b/pyuvsim/tests/test_analyticbeam.py
@@ -267,6 +267,9 @@ def test_chromatic_gaussian():
     az = np.zeros(Npix)
     za = np.linspace(0, np.pi / 2., Npix)
 
+    # Error if trying to define chromatic beam without a reference frequency
+
+    nt.assert_raises(ValueError, pyuvsim.AnalyticBeam, ['gaussian'], dict(sigma=sigma, spectral_index=alpha))
     A = pyuvsim.AnalyticBeam('gaussian', sigma=sigma, ref_freq=freqs[0], spectral_index=alpha)
 
     # Get the widths at each frequency.

--- a/pyuvsim/tests/test_analyticbeam.py
+++ b/pyuvsim/tests/test_analyticbeam.py
@@ -295,10 +295,11 @@ def test_power_analytic_beam():
 
     eb = pyuvsim.AnalyticBeam('gaussian', diameter=diam)
     pb = pyuvsim.AnalyticBeam('gaussian', diameter=diam)
-    pb.efield_to_pstokes()
+    pb.efield_to_power()
     evals = eb.interp(az, za, freqs)[0][0, 0, 0]
     pvals = pb.interp(az, za, freqs)[0][0, 0]
-    nt.assert_true(np.allclose(evals**2, pvals))
+
+    nt.assert_true(np.allclose(evals**2, pvals / 2.))
 
 
 def test_comparison():

--- a/pyuvsim/tests/test_analyticbeam.py
+++ b/pyuvsim/tests/test_analyticbeam.py
@@ -285,6 +285,23 @@ def test_chromatic_gaussian():
         nt.assert_true(np.isclose(sig_f, 2 * hwhm / 2.355, atol=1e-3))
 
 
+def test_power_analytic_beam():
+    freqs = np.arange(120e6, 160e6, 4e6)
+    Nfreqs = len(freqs)
+    Npix = 1000
+    diam = 14.0
+
+    az = np.zeros(Npix)
+    za = np.linspace(0, np.pi / 2., Npix)
+
+    eb = pyuvsim.AnalyticBeam('gaussian', diameter=diam)
+    pb = pyuvsim.AnalyticBeam('gaussian', diameter=diam)
+    pb.efield_to_pstokes()
+    evals = eb.interp(az, za, freqs)[0][0, 0, 0]
+    pvals = pb.interp(az, za, freqs)[0][0, 0]
+    nt.assert_true(np.allclose(evals**2, pvals))
+
+
 def test_comparison():
     """
     Beam __eq__ method

--- a/pyuvsim/tests/test_analyticbeam.py
+++ b/pyuvsim/tests/test_analyticbeam.py
@@ -268,8 +268,7 @@ def test_chromatic_gaussian():
     za = np.linspace(0, np.pi / 2., Npix)
 
     # Error if trying to define chromatic beam without a reference frequency
-
-    nt.assert_raises(ValueError, pyuvsim.AnalyticBeam, ['gaussian'], dict(sigma=sigma, spectral_index=alpha))
+    nt.assert_raises(ValueError, pyuvsim.AnalyticBeam, 'gaussian', sigma=sigma, spectral_index=alpha)
     A = pyuvsim.AnalyticBeam('gaussian', sigma=sigma, ref_freq=freqs[0], spectral_index=alpha)
 
     # Get the widths at each frequency.

--- a/pyuvsim/tests/test_analyticbeam.py
+++ b/pyuvsim/tests/test_analyticbeam.py
@@ -252,6 +252,36 @@ def test_gaussbeam_values():
     nt.assert_true(np.all(beam_values**2 == coherencies))
 
 
+def test_chromatic_gaussian():
+    """
+    test_chromatic_gaussian
+    Defining a gaussian beam with a spectral index and reference frequency.
+    Check that beam width follows prescribed power law.
+    """
+    freqs = np.arange(120e6, 160e6, 4e6)
+    Nfreqs = len(freqs)
+    Npix = 1000
+    alpha = -1.5
+    sigma = np.radians(15.0)
+
+    az = np.zeros(Npix)
+    za = np.linspace(0, np.pi / 2., Npix)
+
+    A = pyuvsim.AnalyticBeam('gaussian', sigma=sigma, ref_freq=freqs[0], spectral_index=alpha)
+
+    # Get the widths at each frequency.
+
+    vals, _ = A.interp(az, za, freqs)
+
+    vals = vals[0, 0, 0]
+
+    for fi in range(Nfreqs):
+        hwhm = za[np.argmin(np.abs(vals[fi] - 0.5))]
+        sig_f = sigma * (freqs[fi] / freqs[0])**alpha
+        print(sig_f, 2 * hwhm / 2.355)
+        nt.assert_true(np.isclose(sig_f, 2 * hwhm / 2.355, atol=1e-3))
+
+
 def test_comparison():
     """
     Beam __eq__ method


### PR DESCRIPTION
This is a first step toward moving functions in `healvis` back to `pyuvsim`. `healvis` simulations use analytic power beams, which are not currently available in `pyuvsim`, and has the option to use chromatic gaussians whose widths change with frequency according to a user-specified power law.