### PR TITLE
Memory-saving measures for large Sky Models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+
+## Added
+- A means for monitoring the memory usage on each Node
+
 ### Changed
 - Replaced init_uvdata_out function with complete_uvdata
 - init_uvdata_out function is more modular.
@@ -10,6 +14,7 @@
 - Added functions to read healpix maps and added support for frequency axis
 
 ### Fixed
+- skymodel splitting was not working correctly to avoid running out of memory.
 - Flush stderr in excepthook, so stack trace is printed when an exception is raised in MPI.
 - No longer calling UVBeam.interp with freq_interp_kind, for updated pyuvdata.
 - Circular-installation bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added functions to read healpix maps and added support for frequency axis
 
 ### Fixed
+- Flush stderr in excepthook, so stack trace is printed when an exception is raised in MPI.
 - No longer calling UVBeam.interp with freq_interp_kind, for updated pyuvdata.
 - Circular-installation bug
 - Bug in how integration_time array is set in setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 
 ## Added
-- A means for monitoring the memory usage on each Node
+- A function for checking the memory usage on each Node
 
 ### Changed
 - Replaced init_uvdata_out function with complete_uvdata

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - scipy>=1.0.1
   - PyYAML>=5.1
   - mpi4py>=3.0.0
-  - astropy>=2.0
+  - astropy>=2.0.16
   - pip
   - psutil
   - line_profiler

--- a/pyuvsim/mpi.py
+++ b/pyuvsim/mpi.py
@@ -206,8 +206,13 @@ def get_max_node_rss(return_per_node=False):
         Only returns to the zero-th rank on the world_comm.
     """
 
-    # KiB -> GiB
-    memory_usage_GiB = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 2**10 / 2**30
+    # On linux, getrusage returns in kiB
+    # On Mac systems, getrusage returns in B
+    scale = 1.0
+    if sys.platform == 'linux':
+        scale = 2**10
+
+    memory_usage_GiB = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * scale / 2**30
     node_mem_tot = node_comm.allreduce(memory_usage_GiB, op=MPI.SUM)
     if return_per_node:
         return node_mem_tot

--- a/pyuvsim/mpi.py
+++ b/pyuvsim/mpi.py
@@ -27,6 +27,7 @@ def set_mpi_excepthook(mpi_comm):
 
     def mpi_excepthook(exctype, value, traceback):  # pragma: no cover
         sys.__excepthook__(exctype, value, traceback)
+        sys.stderr.flush()
         mpi_comm.Abort(1)
 
     sys.excepthook = mpi_excepthook
@@ -54,7 +55,6 @@ def start_mpi():
     if not rank == 0:  # pragma: no cover
         # For non-root ranks, do not print to stdout.
         # (Uncovered until we have multi-rank tests)
-        global stdout
         sys.stdout = open('/dev/null', 'w')
 
 

--- a/pyuvsim/mpi.py
+++ b/pyuvsim/mpi.py
@@ -209,7 +209,7 @@ def get_max_node_rss(return_per_node=False):
     # On linux, getrusage returns in kiB
     # On Mac systems, getrusage returns in B
     scale = 1.0
-    if sys.platform == 'linux':
+    if 'linux' in sys.platform:
         scale = 2**10
 
     memory_usage_GiB = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * scale / 2**30

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -160,7 +160,7 @@ def test_mem_usage():
     arr = bytearray(incsize)
     time.sleep(1)
     change = mpi.get_max_node_rss() - memory_usage_GiB
-    assert np.isclose(change, incsize / 2**30, atol=1e-2)
+    assert np.isclose(change, incsize / 2**30, atol=5e-2)
     del arr
 
 

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -57,18 +57,14 @@ class progsteps:
         self.step = step
         self.curval = -1
 
-    def update(self, count, mem=None):
+    def update(self, count):
         """
         Update the progress bar.
 
         Parameters
         ----------
-
         count : int
             Current value of counter
-        mem : float (optional)
-            Maximum current per-node memory usage in GB.
-            If provided, this information will also be printed.
         """
         if count >= self.curval + self.step:
             doprint = False
@@ -78,12 +74,9 @@ class progsteps:
             if doprint:
                 ostr = "{:0.2f}% completed. {:0.3f} minutes elapsed".format(
                     (count / self.maxval) * 100., (pytime.time() - self.t0) / 60.)
-                if mem is not None:
-                    ostr += ", MaxRSS = {:0.3f} GB\n".format(mem)
-                else:
-                    ostr += '\n'
+                ostr += '\n'
                 print(ostr)
-            sys.stdout.flush()
+                sys.stdout.flush()
 
     def finish(self):
         self.update(self.maxval)

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -36,7 +36,14 @@ def get_version_string():
 
 class progsteps:
     """
-        Similar to a progress bar, this prints a percentage of task completion.
+    Similar to a progress bar, this prints a percentage of task completion.
+
+    Parameters
+    ----------
+
+    maxval : int
+        Maximum value to count to.
+
     """
 
     def __init__(self, maxval=None):
@@ -50,15 +57,32 @@ class progsteps:
         self.step = step
         self.curval = -1
 
-    def update(self, count):
+    def update(self, count, mem=None):
+        """
+        Update the progress bar.
+
+        Parameters
+        ----------
+
+        count : int
+            Current value of counter
+        mem : float (optional)
+            Maximum current per-node memory usage in GB.
+            If provided, this information will also be printed.
+        """
         if count >= self.curval + self.step:
             doprint = False
             if not self.curval == count:
                 doprint = True
                 self.curval = count
             if doprint:
-                print("{:0.2f}% completed. {:0.3f} minutes elapsed \n".format(
-                    (count / self.maxval) * 100., (pytime.time() - self.t0) / 60.))
+                ostr = "{:0.2f}% completed. {:0.3f} minutes elapsed".format(
+                    (count / self.maxval) * 100., (pytime.time() - self.t0) / 60.)
+                if mem is not None:
+                    ostr += ", MaxRSS = {:0.3f} GB\n".format(mem)
+                else:
+                    ostr += '\n'
+                print(ostr)
             sys.stdout.flush()
 
     def finish(self):

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -246,7 +246,6 @@ def uvdata_to_task_iter(task_ids, input_uv, catalog, beam_list, beam_dict, Nsky_
 
     freq_array = input_uv.freq_array * units.Hz
     time_array = Time(input_uv.time_array, scale='utc', format='jd', location=telescope.location)
-
     for src_i in src_iter:
         sky = simsetup.array_to_skymodel(catalog[src_i])
         if sky.spectral_type == 'values':
@@ -392,10 +391,9 @@ def run_uvdata_uvsim(input_uv, beam_list, beam_dict=None, catalog=None):
         else:
             summed_task_dict[task.uvdata_index].visibility_vector += engine.make_visibility()
 
-        max_mem = mpi.get_max_node_rss()
         count.next()
         if rank == 0:
-            pbar.update(count.current_value(), max_mem)
+            pbar.update(count.current_value())
 
     comm.Barrier()
     count.free()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Improves on several memory-saving techniques and fixes some bugs with it:
- A new method for estimating the required memory for a SkyModel object, which includes the effect of the new source frequency axis.
- A better assessment of memory use on each node, which determines how a catalog will be split up.
- Fixes a bug that was causing the catalog to be copied out of shared memory onto each rank before making sky models, essentially defeating the purpose of using shared memory.

Also fixes a minor bug that prevented errors from being printed:
- Fixes a bug that prevented the stack trace from being printed on Oscar when an exception was raised while MPI was active.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Originally, `mpi.py` was written for MPI-2, which (if I recall correctly) had a bug where an exception raised on one rank would not kill the whole job, causing jobs to hang. To fix this, I replaced the default excepthook with one that makes an explicit call to MPI.Abort() after printing the stack trace.

The simplest solution is just to flush the stderr before calling Abort. Stack traces are now reaching the user, which will make it easier to diagnose problems. However, I think in MPI-3 (which we require), an exception on one rank kills the whole job, so we probably don't need to overwrite the excepthook anyway.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes #244 
## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
  (I don't think this is possible without mpi enabled tests).
- [x] All new and existing tests pass in both python 2 and python 3.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the documentation to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass in both python 2 and python 3.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).
