### PR TITLE
Multiple analytic beams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: trusty
 language: python
 python:
   # We don't actually use the Travis Python, but this keeps it organized.
-  - "2.7"
   - "3.6"
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+- Support for individual shape parameters for analytic beams.
+
+### Changed
+
+### Fixed
+- Removed warning catch for astropy GLEAM read in tests -- new versions don't raise the warning.
+
 ## [1.1.1] - 2019-11-14
 
-## Added
+### Added
 - A function for checking the memory usage on each Node
 
 ### Changed

--- a/docs/example_configs/bl_lite_mixed.yaml
+++ b/docs/example_configs/bl_lite_mixed.yaml
@@ -1,6 +1,8 @@
 beam_paths:
   0: 'hera.uvbeam'
-  1: 'airy'
-diameter: 16
+  1: 'airy', diameter=16
+  2: 'gaussian', sigma=0.03
+  3: 'airy'
+diameter: 12
 telescope_location: (-30.72152777777791, 21.428305555555557, 1073.0000000093132)
 telescope_name: BLLITE

--- a/docs/parameter_files.rst
+++ b/docs/parameter_files.rst
@@ -139,7 +139,7 @@ Telescope Configuration
 
     .. literalinclude:: example_configs/bl_lite_mixed.yaml
 
-    This yaml file provides the telescope name, location in latitude/longitude/altitude in degrees/degrees/meters (respectively), and the `beam dictionary`. In this case, beam_id == 0 is the UVBeam file written out to hera.uvbeam, and beam_id == 1 is an Airy beam with diameter 16m. The dictionary only needs to be as long as the number of unique beams used in the array, while the layout file specifies which antennas will use which beam type. This allows for a mixture of beams to be used, as in this example.
+    This yaml file provides the telescope name, location in latitude/longitude/altitude in degrees/degrees/meters (respectively), and the `beam dictionary`. In this case, beam_id == 0 is the UVBeam file hera.uvbeam, beam_id == 1 is an Airy disk with diameter 14 m, beam_id == 2 is a Gaussian beam with sigma 0.03, and beam_id == 3 is another Airy beam. When no shape parameter is written inline in the beam_dictionary (as with 3), pyuvsim will look for a default parameter below. So in this case, the beam_id == 3 ends up with a diameter of 12 m. The dictionary only needs to be as long as the number of unique beams used in the array, while the layout file specifies which antennas will use which beam type. This allows for a mixture of beams to be used, as in this example. Unassigned beams will be ignored (the given layout file does not use beams 2 or 3).
 
     Analytic beams may require additional parameters.
 
@@ -147,7 +147,7 @@ Telescope Configuration
     - gaussian = Gaussian function shaped beam. Requires either an antenna diameter (in meters) or a standard deviation sigma (in radians). This standard deviation sets the width of the beam in zenith angle. Note that defining gaussian beams via `sigma` will be deprecated in the future.
     - airy = Airy disk (ie, diffraction pattern of a circular aperture). Requires an antenna diameter.
 
-    These extra keywords should be included after the beam dictionary in the telescope config file. Note that beams defined with an antenna diameter will be chromatic. That is, their widths on the sky will change with frequency.
+    Note that beams defined with an antenna diameter will be chromatic (their widths on the sky will change with frequency).
 
     The figure below shows the array created by these configurations, with beam type indicated by color.
 

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -79,7 +79,7 @@ class AnalyticBeam(object):
 
         self.sigma = sigma
         if self.type == 'gaussian' and self.sigma is not None:
-            warnings.warn("Achromatic gaussian beams will not be supported in the future."
+            warnings.warn("Achromatic gaussian beams will not be supported in the future. "
                           + "Define your gaussian beam by a dish diameter from now on.",
                           PendingDeprecationWarning)
 

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -619,30 +619,37 @@ def parse_telescope_params(tele_params, config_path=''):
     """
     Parse the "telescope" section of obsparam.
 
-    Args:
-        tele_params: Dictionary of telescope parameters
-            See pyuvsim documentation for allowable keys.
-            https://pyuvsim.readthedocs.io/en/latest/parameter_files.html#telescope-configuration
-        config_path: str
-            path to directory holding configuration and layout files.
+    Parameters
+    ----------
+    tele_params : dict
+        Telescope parameters
+        See pyuvsim documentation for allowable keys.
+        https://pyuvsim.readthedocs.io/en/latest/parameter_files.html#telescope-configuration
+    config_path : str
+        Path to directory holding configuration and layout files.
 
-    Returns:
-        param_dict : dict
-            * `Nants_data`: Number of antennas
-            * `Nants_telescope`: Number of antennas
-            *  `antenna_names`: list of antenna names
-            * `antenna_numbers`: corresponding list of antenna numbers
-            * `antenna_positions`: Array of ECEF antenna positions
-            * `telescope_location`: ECEF array center location
-            * `telescope_location_lat_lon_alt`: Lat Lon Alt array center location
-            * `telescope_config_file`: Path to configuration yaml file
-            * `antenna_location_file`: Path to csv layout file
-            * `telescope_name`: observatory name
+    Returns
+    -------
+    param_dict : dict
+        Parameters related to the telescope and antenna layout, to be included in the
+        UVData object.
 
-        beam_list : list of :class:`pyuvdata.UVBeam` or `pyuvsim.AnalyticBeam`
-            Beam models in the configuration.
-        beam_dict : dict
-            Antenna numbers to beam indices
+        * `Nants_data`: Number of antennas
+        * `Nants_telescope`: Number of antennas
+        *  `antenna_names`: list of antenna names
+        * `antenna_numbers`: corresponding list of antenna numbers
+        * `antenna_positions`: Array of ECEF antenna positions
+        * `telescope_location`: ECEF array center location
+        * `telescope_location_lat_lon_alt`: Lat Lon Alt array center location
+        * `telescope_config_file`: Path to configuration yaml file
+        * `antenna_location_file`: Path to csv layout file
+        * `telescope_name`: observatory name
+    beam_list : list of str
+        Beam models in the configuration.
+        The strings provide either paths to beamfits files or the specifications to make
+        a :class:`pyuvsim.AnalyticBeam`.
+    beam_dict : dict
+        Antenna numbers to beam indices
     """
     tele_params = copy.deepcopy(tele_params)
     # check for telescope config

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1231,14 +1231,14 @@ def initialize_uvdata_from_params(obs_params):
                 bls = ast.literal_eval(bls)
                 select_params['bls'] = bls
         if len(select_params) > 0:
-            select_params['metadata_only'] = True
+#            select_params['metadata_only'] = True
             uv_obj.select(**select_params)
 
         if no_autos:
-            uv_obj.select(ant_str='cross', metadata_only=True)
+            uv_obj.select(ant_str='cross')#, metadata_only=True)
 
         if redundant_threshold is not None:
-            uv_obj.compress_by_redundancy(tol=redundant_threshold, metadata_only=True)
+            uv_obj.compress_by_redundancy(tol=redundant_threshold)#, metadata_only=True)
 
     return uv_obj, beam_list, beam_dict
 

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -631,7 +631,6 @@ def _construct_beam_list(beam_ids, telconfig):
         # Failing that, try to parse the beam string as an analytic beam.
         else:
             find_type = [t in beam_model for t in AnalyticBeam.supported_types]
-
             if np.sum(find_type) > 1:
                 raise ValueError("Ambiguous beam specification: {}".format(beam_model))
             if np.sum(find_type) == 0:

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1231,14 +1231,13 @@ def initialize_uvdata_from_params(obs_params):
                 bls = ast.literal_eval(bls)
                 select_params['bls'] = bls
         if len(select_params) > 0:
-#            select_params['metadata_only'] = True
             uv_obj.select(**select_params)
 
         if no_autos:
-            uv_obj.select(ant_str='cross')#, metadata_only=True)
+            uv_obj.select(ant_str='cross')
 
         if redundant_threshold is not None:
-            uv_obj.compress_by_redundancy(tol=redundant_threshold)#, metadata_only=True)
+            uv_obj.compress_by_redundancy(tol=redundant_threshold)
 
     return uv_obj, beam_list, beam_dict
 

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -67,15 +67,17 @@ def _parse_layout_csv(layout_csv):
                          dtype=dt.dtype)
 
 
-def _write_layout_csv(filepath, antpos_enu, antenna_names, antenna_numbers):
+def _write_layout_csv(filepath, antpos_enu, antenna_names, antenna_numbers, beam_ids=None):
     col_width = max([len(name) for name in antenna_names])
     header = ("{:" + str(col_width) + "} {:8} {:8} {:10} {:10} {:10}\n").format(
         "Name", "Number", "BeamID", "E", "N", "U"
     )
+    if beam_ids is None:
+        beam_ids = np.zeros(len(antenna_names), dtype=int)
     with open(filepath, 'w') as lfile:
         lfile.write(header + '\n')
         for i, (e, n, u) in enumerate(antpos_enu):
-            beam_id = 0
+            beam_id = beam_ids[i]
             name = antenna_names[i]
             num = antenna_numbers[i]
             line = (

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -755,37 +755,64 @@ def parse_telescope_params(tele_params, config_path=''):
         which_ants = antnames[np.where(beam_ids == beamID)]
         for a in which_ants:
             beam_dict[a] = beamID
-        if beam_model in AnalyticBeam.supported_types:
+
+        # First, check to see if the string specifies a beam path.
+        altpath = os.path.join(SIM_DATA_PATH, beam_model)
+        if os.path.exists(beam_model):
+            beam_list.append(beam_model)
+        elif os.path.exists(altpath):
+            beam_list.append(altpath)
+        # Failing that, try to parse the beam string as an analytic beam.
+        else:
+            find_type = [ t in beam_model for t in AnalyticBeam.supported_types]
+
+            if np.sum(find_type) > 1:
+                raise ValueError("Ambiguous beam specification: {}".format(beam_model))
+            if np.sum(find_type) == 0:
+                raise ValueError("Undefined beam model: {}".format(beam_model))
+
+            beam_type = AnalyticBeam.supported_types[find_type.index(True)]
+
+            beam_model = "".join(beam_model.split())    # Remove whitespace
+            mod_list = beam_model.split(',')
+            inline_beam_opts = {}
+            for opt in mod_list:
+                if '=' not in opt:
+                    continue
+                k,v = opt.split('=')
+                inline_beam_opts[k] = v
+
             # Gaussian beam requires either diameter or sigma
             # Airy beam requires diameter
-            if beam_model == 'uniform':
+
+            # Default to None for diameter and sigma.
+            # Values in the "beam_paths" override globally-defined options.
+            beam_opts = {'diameter' : None, 'sigma' : None}
+            for opt in beam_opts.keys():
+                val = telconfig.get(opt, None)
+                val = inline_beam_opts.get(opt, val)
+                beam_opts[opt] = val
+
+            diameter = beam_opts['diameter']
+            sigma = beam_opts['sigma']
+
+            if beam_type == 'uniform':
                 beam_model = 'analytic_uniform'
-            if beam_model == 'gaussian':
-                try:
-                    diam = telconfig['diameter']
-                    beam_model = '_'.join(['analytic', beam_model, 'diam', str(diam)])
-                except KeyError:
-                    try:
-                        sigma = telconfig['sigma']
-                        beam_model = '_'.join(['analytic', beam_model, 'sig', str(sigma)])
-                    except KeyError:
-                        raise KeyError(
-                            "Missing shape parameter for gaussian beam (diameter or sigma)."
-                        )
-            if beam_model == 'airy':
-                try:
-                    diam = telconfig['diameter']
-                    beam_model = '_'.join(['analytic', beam_model, 'diam', str(diam)])
-                except KeyError:
+
+            if beam_type == 'gaussian':
+                if diameter is not None:
+                    beam_model = '_'.join(['analytic_gaussian', 'diam', str(diameter)])
+                elif sigma is not None:
+                    beam_model = '_'.join(['analytic_gaussian', 'sig', str(sigma)])
+                else:
+                    raise KeyError("Missing shape parameter for gaussian beam (diameter or sigma).")
+            if beam_type == 'airy':
+                if diameter is not None:
+                    beam_model = '_'.join(['analytic_airy', 'diam', str(diameter)])
+                else:
                     raise KeyError("Missing diameter for airy beam.")
-        else:
-            # If not analytic, it's a beamfits file path.
-            if not os.path.exists(beam_model):
-                path = os.path.join(SIM_DATA_PATH, beam_model)
-                beam_model = path
-                if not os.path.exists(path):
-                    raise OSError("Could not find file " + beam_model)
-        beam_list.append(beam_model)
+
+            beam_list.append(beam_model)
 
     return return_dict, beam_list, beam_dict
 

--- a/pyuvsim/tests/conftest.py
+++ b/pyuvsim/tests/conftest.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import shutil
+import warnings
 
 import pytest
 import six.moves.urllib as urllib
@@ -41,3 +42,9 @@ def setup_and_teardown_package():
     # clean up the test directory after
     if os.path.exists(testdir):
         shutil.rmtree(testdir)
+
+
+@pytest.fixture(autouse=True)
+def ignore_center_deprecation():
+    warnings.filterwarnings('ignore', message='The default for the `center` keyword has changed.',
+                            category=DeprecationWarning)

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -11,6 +11,7 @@ import numpy as np
 import yaml
 import resource
 import time
+import six
 
 mpi4py.rc.initialize = False  # noqa
 import pytest
@@ -87,12 +88,15 @@ def test_run_paramfile_uvsim():
     os.remove(tempfilename)
 
     param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testvot.yaml')
-    uvtest.checkWarnings(
-        pyuvsim.uvsim.run_uvsim, [param_filename],
-        nwarnings=1,
-        message=['The default for the `center` keyword has changed'],
-        category=[DeprecationWarning]
-    )
+    if six.PY2:
+        pyuvsim.uvsim.run_uvsim(param_filename)
+    else:
+        uvtest.checkWarnings(
+            pyuvsim.uvsim.run_uvsim, [param_filename],
+            nwarnings=1,
+            message=['The default for the `center` keyword has changed'],
+            category=[DeprecationWarning]
+        )
 
     uv_new_vot = UVData()
     uvtest.checkWarnings(uv_new_vot.read_uvfits, [tempfilename], nwarnings=1,

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -15,7 +15,6 @@ import time
 mpi4py.rc.initialize = False  # noqa
 import pytest
 from mpi4py import MPI
-import astropy
 
 from pyuvdata import UVData
 from pyuvdata.data import DATA_PATH

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -11,7 +11,6 @@ import numpy as np
 import yaml
 import resource
 import time
-import six
 
 mpi4py.rc.initialize = False  # noqa
 import pytest

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -78,9 +78,8 @@ def test_run_paramfile_uvsim():
     tempfilename = params_dict['filing']['outfile_name']
 
     # This test obsparam file has "single_source.txt" as its catalog.
-    uvtest.checkWarnings(pyuvsim.uvsim.run_uvsim, [param_filename], nwarnings=1,
-                         message=['The default for the `center` keyword'],
-                         category=[DeprecationWarning])
+    pyuvsim.uvsim.run_uvsim(param_filename)
+
     uv_new_txt = UVData()
     uvtest.checkWarnings(uv_new_txt.read_uvfits, [tempfilename],
                          message='antenna_diameters is not set')
@@ -88,15 +87,7 @@ def test_run_paramfile_uvsim():
     os.remove(tempfilename)
 
     param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testvot.yaml')
-    if six.PY2:
-        pyuvsim.uvsim.run_uvsim(param_filename)
-    else:
-        uvtest.checkWarnings(
-            pyuvsim.uvsim.run_uvsim, [param_filename],
-            nwarnings=1,
-            message=['The default for the `center` keyword has changed'],
-            category=[DeprecationWarning]
-        )
+    pyuvsim.uvsim.run_uvsim(param_filename)
 
     uv_new_vot = UVData()
     uvtest.checkWarnings(uv_new_vot.read_uvfits, [tempfilename], nwarnings=1,

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -90,9 +90,9 @@ def test_run_paramfile_uvsim():
     param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testvot.yaml')
     uvtest.checkWarnings(
         pyuvsim.uvsim.run_uvsim, [param_filename],
-        nwarnings=11,
-        message=[SIM_DATA_PATH] * 10 + ['The default for the `center` keyword has changed'],
-        category=[astropy.io.votable.exceptions.W50] * 10 + [DeprecationWarning]
+        nwarnings=1,
+        message=['The default for the `center` keyword has changed'],
+        category=[DeprecationWarning]
     )
 
     uv_new_vot = UVData()

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -180,10 +180,7 @@ def test_param_reader(config_num):
     Ntasks = hera_uv.Nblts * hera_uv.Nfreqs
     taskiter = pyuvsim.uvdata_to_task_iter(range(Ntasks), hera_uv, sources,
                                            beam_list, beam_dict=beam_dict)
-    expected_uvtask_list = uvtest.checkWarnings(
-        list, [taskiter], message='The default for the `center` keyword has changed',
-        category=DeprecationWarning
-    )
+    expected_uvtask_list = list(taskiter)
 
     # Check error conditions:
     if config_num == 0:
@@ -261,10 +258,7 @@ def test_param_reader(config_num):
     taskiter = pyuvsim.uvdata_to_task_iter(
         range(Ntasks), hera_uv, sources, beam_list, beam_dict=beam_dict
     )
-    uvtask_list = uvtest.checkWarnings(
-        list, [taskiter], message='The default for the `center` keyword has changed',
-        category=DeprecationWarning
-    )
+    uvtask_list = list(taskiter)
 
     # Tasks are not ordered in UVTask lists, so need to sort them.
     uvtask_list = sorted(uvtask_list)

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -339,8 +339,9 @@ def test_offzenith_source_multibl_uvfits():
     # get antennas positions into ENU
     antpos, ants = uvtest.checkWarnings(
         hera_uv.get_ENU_antpos, category=[DeprecationWarning],
-        message=['The xyz array in ENU_from_ECEF is being interpreted as (Npts, 3)'],
-        nwarnings=1
+        message=['The default for the `center` ',
+                 'The xyz array in ENU_from_ECEF is being interpreted as (Npts, 3)'],
+        nwarnings=2
     )
     antenna1 = pyuvsim.Antenna('ant1', ants[0], np.array(antpos[0, :]), 0)
     antenna2 = pyuvsim.Antenna('ant2', ants[1], np.array(antpos[1, :]), 0)

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -339,9 +339,8 @@ def test_offzenith_source_multibl_uvfits():
     # get antennas positions into ENU
     antpos, ants = uvtest.checkWarnings(
         hera_uv.get_ENU_antpos, category=[DeprecationWarning],
-        message=['The default for the `center` keyword has changed',
-                 'The xyz array in ENU_from_ECEF is being interpreted as (Npts, 3)'],
-        nwarnings=2
+        message=['The xyz array in ENU_from_ECEF is being interpreted as (Npts, 3)'],
+        nwarnings=1
     )
     antenna1 = pyuvsim.Antenna('ant1', ants[0], np.array(antpos[0, :]), 0)
     antenna2 = pyuvsim.Antenna('ant2', ants[1], np.array(antpos[1, :]), 0)
@@ -417,10 +416,7 @@ def test_file_to_tasks():
     taskiter = pyuvsim.uvdata_to_task_iter(
         np.arange(Ntasks), hera_uv, sources, beam_list, beam_dict
     )
-    uvtask_list = uvtest.checkWarnings(
-        list, [taskiter], message=['The default for the `center` keyword has changed'],
-        category=DeprecationWarning
-    )
+    uvtask_list = list(taskiter)
 
     tlist = copy.deepcopy(uvtask_list)
     # Test task comparisons
@@ -497,10 +493,7 @@ def test_gather():
     beam_dict = dict(zip(hera_uv.antenna_names, [0] * hera_uv.Nants_data))
     taskiter = pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), hera_uv, sources, beam_list,
                                            beam_dict)
-    uvtask_list = uvtest.checkWarnings(
-        list, [taskiter], message=['The default for the `center` keyword has changed'],
-        category=DeprecationWarning
-    )
+    uvtask_list = list(taskiter)
 
     uv_out = pyuvsim.simsetup._complete_uvdata(hera_uv, inplace=False)
     for task in uvtask_list:
@@ -544,10 +537,8 @@ def test_local_task_gen():
     taskiter = pyuvsim.uvdata_to_task_iter(
         np.arange(Ntasks), hera_uv, sources, beam_list, beam_dict
     )
-    uvtask_list = uvtest.checkWarnings(
-        list, [taskiter], message=['The default for the `center` keyword has changed'],
-        category=DeprecationWarning
-    )
+    uvtask_list = list(taskiter)
+
     uvtask_iter = pyuvsim.uvdata_to_task_iter(
         np.arange(Ntasks), hera_uv, copy.deepcopy(sources),
         copy.deepcopy(beam_list), beam_dict
@@ -680,10 +671,7 @@ def test_source_splitting():
         np.arange(Ntasks), hera_uv, sources, beam_list, beam_dict, Nsky_parts=Nsky_parts
     )
 
-    uvtask_list = uvtest.checkWarnings(
-        list, [taskiter], message='The default for the `center` keyword has changed.',
-        category=DeprecationWarning
-    )
+    uvtask_list = list(taskiter)
 
     assert pyuvsim.estimate_skymodel_memory_usage(partsize, 1) * Npus_node < mem_avail
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provides the means to specify diameter, sigma, etc. inline within the "beam_paths" list for telescope configuration files, rather than setting a single global sigma/diameter, etc. For instance:
```
beam_paths:
   0 : airy, diameter=14
   1 : airy, diameter=20
   2 : airy
   3 : gaussian, sigma=0.3
diameter: 30
```
The above will make airy beams for IDs 0, 1, and 2, with diameters 14, 20, and 30 meters respectively. Beam 3 will be a gaussian with sigma parameter 0.3. The "inline" parameters override the global parameter (diameter : 30).

Unsupported parameters are currently ignored.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently, analytic beams may only be defined with one global shape parameter. In order to use various analytic beams across the array, we need to be able to specify different properties for each one.
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #187 

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the documentation to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass in both python 2 and python 3.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).