### PR TITLE
reinstate the conda update step to fix the conda bug in mac 3.8 builds

### DIFF
--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -7,8 +7,7 @@ if [[ ! $OS == 'macos-latest' ]]; then
   sudo apt-get install -y gcc g++
 fi
 conda config --set always_yes yes --set changeps1 no
-# try commenting out the conda update call to see if it fixes issues on mac tests
-# conda update -q conda
+conda update -q conda
 conda info -a
 conda create --name=${ENV_NAME}  python=$PYTHON --quiet
 conda env update -f ci/${ENV_NAME}.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Uncomment the conda update -q conda step in the conda install script used in CI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Conda just released a new version which fixes a bug we have been seeing in Mac 3.8 tests:
`TypeError: sequence item 0: expected str instance, Channel found`  (https://github.com/conda/conda/releases, conda/conda#9748)

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
