### PR TITLE
flux columns compatibility

### DIFF
--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -803,7 +803,4 @@ def test_quantity_reuse():
             assert apcoh_changed and jones_changed
         if time != prev_time:
             # Note -- local_coherency will only change if the sources are polarized.
-            if pol_in_rec:
-                assert srcpos_changed and locoh_changed
-            else:
-                assert srcpos_changed
+            assert srcpos_changed and locoh_changed

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -8,6 +8,7 @@ import os
 
 import astropy.constants as const
 import numpy as np
+from numpy.lib import recfunctions
 import pyuvdata.utils as uvutils
 from astropy import units
 from astropy.coordinates import Angle, SkyCoord, EarthLocation
@@ -742,12 +743,21 @@ def test_quantity_reuse():
         time, arrangement='long-line', Nsrcs=30, return_table=True
     )
 
-    # Temporary switch until PR #54 on pyradiosky is merged.
-    pol_in_rec = hasattr(pyradiosky.SkyModel, 'above_horizon')
-
-    if pol_in_rec:
-        # Give one source polarization
+    # Give one source polarization
+    if 'flux_density' in sources.dtype.names:
+        # For backwards compatibility until PR 60 is merged in pyradiosky.
         sources['flux_density'][15] = [0.3, 0.1, 2.0, 0.0]
+    else:
+        Qcomp = np.zeros(30)
+        Ucomp = np.zeros(30)
+        Vcomp = np.zeros(30)
+        Qcomp[15] = 0.1
+        Ucomp[15] = 2.0
+        Vcomp[15] = 0.0
+        sources['I'][15] = 0.3
+        sources = recfunctions.append_fields(
+            sources, ['Q', 'V', 'U'], [Qcomp, Ucomp, Vcomp]
+        )
 
     beam_list.set_obj_mode()
     taskiter = pyuvsim.uvdata_to_task_iter(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes a test to handle changes in [pyradiosky PR 60](https://github.com/RadioAstronomySoftwareGroup/pyradiosky/pull/60).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A recent (pending) change to pyradiosky removes the `flux_density` column from the recarray form of SkyModel, and replaces it with separate columns for the different Stokes parameters. A single test in pyuvsim references the `flux_density` column and needs to be changed to account for the change in pyradiosky.

The test is backwards compatible with previous versions of pyradiosky. The only difference this makes is for pyradiosky to pass its run of pyuvsim's tests.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass in both python 2 and python 3.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).