### PR TITLE
error if task list is too long for MPI to gather

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Only do beam eval when time, freq, or beam type changes.
 - The definition of the Airy beam now uses the exact value of c, not 3e8.
 
+### Fixed
+- Error early if the task list is too long for gather
+
 ## [1.1.2] - 2020-2-14
 
 ### Added

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -804,3 +804,15 @@ def test_quantity_reuse():
         if time != prev_time:
             # Note -- local_coherency will only change if the sources are polarized.
             assert srcpos_changed and locoh_changed
+
+
+def test_overflow_check():
+    # Ensure error before running sim for too many tasks.
+
+    task_limit = 22118400
+    # This number of tasks is known to produce an overflow error
+    # on bcast/gather operations in MPI.
+    # This test just makes sure that the right error is raised
+    # by the checker function for this value.
+    with pytest.raises(ValueError, match="Too many tasks"):
+        pyuvsim.uvsim._check_ntasks_valid(task_limit)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -377,7 +377,12 @@ def _check_ntasks_valid(Ntasks_tot):
 
     size = (Ntasks_tot + 1) * delta_size
     if size >= INT_MAX_BYTES:
-        raise ValueError(f"Too many tasks for MPI to gather successfully: {Ntasks_tot}")
+        raise ValueError(
+            f"Too many tasks for MPI to gather successfully: {Ntasks_tot}\n"
+            "\t Consider splitting your simulation into multiple smaller jobs "
+            "and joining them together with UVData.\n"
+            "\t This error will go away when issue #289 is closed."
+        )
 
 
 def run_uvdata_uvsim(input_uv, beam_list, beam_dict=None, catalog=None):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

There is a fundamental bug in MPI that limits the size of collective operations -- when a gather, broadcast, scatter, or reduce is performed, the total number of bytes being moved is recorded in a C type 32 bit integer. When more than 2**32 - 1 bytes of data are being moved (around 4 GiB), the size of the data cannot be stored in this integer and there is an overflow error.

When the task list is too long, this error occurs on the gather step, after evaluating all the visibilities. It's a significant nuisance, then, because it means a very long simulation will finish running but error when collecting the results. This change anticipates the size of the gathered task list and raises an error earlier if the bug will come up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is a quick solution to a deeper problem. Ideally, when a large gather is needed, pyuvsim should split up the gather into multiple steps to avoid this issue. For now, however, it will just error before doing any heavy lifting.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #286 
closes #279 

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in both python 2 and python 3.
- [x] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).