### PR TITLE
update PR template to not ask about tests passing python 2

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@
 
 Bug fix checklist:
 - [ ] My fix includes a new test that breaks as a result of the bug (if possible).
-- [ ] All new and existing tests pass in both python 2 and python 3.
+- [ ] All new and existing tests pass in Python 3.6, 3.7, and 3.8 for ubuntu and mac-os.
 - [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
 - [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).
 
@@ -33,7 +33,7 @@ New feature checklist:
 - [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
 - [ ] I have updated the documentation to highlight my new feature (if appropriate).
 - [ ] I have added tests to cover my new feature.
-- [ ] All new and existing tests pass in both python 2 and python 3.
+- [ ] All new and existing tests pass in Python 3.6, 3.7, and 3.8 for ubuntu and mac-os.
 - [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
 - [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).
 
@@ -42,7 +42,7 @@ Breaking change checklist:
 - [ ] I have updated the documentation to reflect my changes (if appropriate).
 - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
 - [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests pass in both python 2 and python 3.
+- [ ] All new and existing tests pass in Python 3.6, 3.7, and 3.8 for ubuntu and mac-os.
 - [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
 - [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,7 @@
 
 Bug fix checklist:
 - [ ] My fix includes a new test that breaks as a result of the bug (if possible).
-- [ ] All new and existing tests pass in Python 3.6, 3.7, and 3.8 for ubuntu and mac-os.
+- [ ] All new and existing tests pass.
 - [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
 - [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).
 
@@ -33,7 +33,7 @@ New feature checklist:
 - [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
 - [ ] I have updated the documentation to highlight my new feature (if appropriate).
 - [ ] I have added tests to cover my new feature.
-- [ ] All new and existing tests pass in Python 3.6, 3.7, and 3.8 for ubuntu and mac-os.
+- [ ] All new and existing tests pass.
 - [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
 - [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).
 
@@ -42,7 +42,7 @@ Breaking change checklist:
 - [ ] I have updated the documentation to reflect my changes (if appropriate).
 - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
 - [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests pass in Python 3.6, 3.7, and 3.8 for ubuntu and mac-os.
+- [ ] All new and existing tests pass.
 - [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
 - [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The current PR template asks the contributor to confirm that tests pass in both python 2 and 3. Since pyuvsim no longer supports python 2, this is no longer necessary.

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [x] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
