### PR TITLE
lunarsky support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- quiet keyword for run_uvsim, to suppress stdout printing.
+- Support for Moon-based observing -- keyword "world: moon" in telescope config.
 - Option to pass along interpolating spline order to UVBeam from teleconfig file.
 - Scripts for running / verifying reference simulations.
 - Benchmarking tools.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Optional:
 * mpi4py>=3.0.0
 * psutil
 * line_profiler
+* lunarsky
 
 ### Developer Installation
 If you are developing `pyuvsim`, you will need to download and install the

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -19,4 +19,4 @@ dependencies:
   - setuptools_scm
   - pip:
     - pyradiosky
-    - git+https://github.com/aelanman/lunarsky.git
+    - lunarsky

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -19,3 +19,4 @@ dependencies:
   - setuptools_scm
   - pip:
     - pyradiosky
+    - git+https://github.com/aelanman/lunarsky.git

--- a/docs/example_configs/tranquility_config.yaml
+++ b/docs/example_configs/tranquility_config.yaml
@@ -1,0 +1,5 @@
+beam_paths:
+    0 : 'uniform'
+telescope_location: (0.6875, 24.433, 0)
+world: 'moon'
+telescope_name: apollo11

--- a/docs/parameter_files.rst
+++ b/docs/parameter_files.rst
@@ -183,6 +183,16 @@ Telescope Configuration
 	    :width: 600
 	    :alt: Graphical depiction of the example antenna layout.
 
+Telescopes on the Moon
+~~~~~~~~~~~~~~~~~~~~~~
+   If the ``lunarsky`` module is installed, the ``telescope_location`` can be interpreted as the
+   lon/lat/alt of an observatory on the Moon, defined in the "Mean Earth/ Mean Rotation"
+   frame (see documentation on ``lunarsky``). Setting the keyword ``world: moon`` in the telescope_config
+   file enables this:
+
+   .. literalinclude:: example_configs/tranquility_config.yaml
+
+
 Sources
 ^^^^^^^
     Specify the path to a text catalog file via ``catalog``. The path can be given as an absolute path or relative to the location of the obsparam. This catalog should be readable with `pyradiosky`.

--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,4 @@ dependencies:
   - pip:
     - pre-commit
     - pyradiosky
+    - lunarsky

--- a/pyuvsim/astropy_interface.py
+++ b/pyuvsim/astropy_interface.py
@@ -1,0 +1,37 @@
+# -*- mode: python; coding: utf-8 -*
+# Copyright (c) 2020 Radio Astronomy Software Group
+# Licensed under the 3-clause BSD License
+
+"""
+Special import interface for astropy.
+
+The lunarsky module wraps several classes in astropy. This module
+provides the classes from lunarsky if it's installed, or from astropy if
+it isn't.
+
+Provides:
+    * MoonLocation -- Equivalent to EarthLocation.
+    * LunarTopo    -- An AltAz frame on the Moon.
+    * Time         -- astropy Time class that works with MoonLocation.
+    * SkyCoord     -- source coordinate position compatible with MoonLocation.
+
+The lunarsky classes are entirely compatible with normal astropy behavior, even
+if observing locations on the Moon are not used.
+"""
+
+try:
+    from lunarsky import SkyCoord, MoonLocation, LunarTopo, Time
+    hasmoon = True
+except ImportError:
+    from astropy.coordinates import SkyCoord
+    from astropy.time import Time
+    hasmoon = False
+
+    class MoonLocation:
+        pass
+
+    class LunarTopo:
+        pass
+
+for obj in [SkyCoord, MoonLocation, LunarTopo, Time]:
+    assert obj

--- a/pyuvsim/data/test_config/obsparam_tranquility_hex.yaml
+++ b/pyuvsim/data/test_config/obsparam_tranquility_hex.yaml
@@ -1,0 +1,18 @@
+filing:
+  outdir: '.'
+  outfile_name: 'sim_results.uvfits'
+freq:
+  Nfreqs: 10
+  bandwidth: 800000.0
+  start_freq: 100000000.0
+sources:
+  catalog: 'mock'
+  mock_arrangement: 'zenith'
+telescope:
+  array_layout: 'layout_hex37_14.6m.csv'
+  telescope_config_name: '../tranquility_config.yaml'
+time:
+  Ntimes: 10
+  duration_days: 0.0012731478148148147
+  integration_time: 11.0
+  start_time: 2457458.1738949567

--- a/pyuvsim/data/tranquility_config.yaml
+++ b/pyuvsim/data/tranquility_config.yaml
@@ -1,0 +1,5 @@
+beam_paths:
+    0 : 'uniform'
+telescope_location: (0.6875, 24.433, 0)
+world: 'moon'
+telescope_name: apollo11

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -966,7 +966,8 @@ def initialize_uvdata_from_params(obs_params):
                 val = tele_dict[key]
                 if isinstance(val, str):
                     extra_keywords[key] = val
-    extra_keywords['world'] = tele_params.get('world', 'earth')
+    if "world" in tele_params:
+        extra_keywords['world'] = tele_params.get('world')
     uvparam_dict['extra_keywords'] = extra_keywords
 
     # Parse frequency structure

--- a/pyuvsim/tests/test_analyticbeam.py
+++ b/pyuvsim/tests/test_analyticbeam.py
@@ -7,7 +7,6 @@ import os
 import numpy as np
 from astropy import units
 from astropy.coordinates import Angle, EarthLocation
-from astropy.time import Time
 import pytest
 from pyuvdata import UVData
 from scipy.special import j1
@@ -15,6 +14,7 @@ from scipy.special import j1
 import pyuvsim
 import pyuvsim.utils as simutils
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
+from pyuvsim.astropy_interface import Time
 
 EW_uvfits_file = os.path.join(SIM_DATA_PATH, '28mEWbl_1time_1chan.uvfits')
 

--- a/pyuvsim/tests/test_mpi_uvsim.py
+++ b/pyuvsim/tests/test_mpi_uvsim.py
@@ -15,7 +15,6 @@ pytest.importorskip('mpi4py')  # noqa
 import mpi4py
 mpi4py.rc.initialize = False  # noqa
 from mpi4py import MPI
-from astropy.time import Time
 from astropy import units
 from astropy.coordinates import Latitude, Longitude
 

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -9,7 +9,6 @@ import shutil
 import numpy as np
 import pytest
 import yaml
-import warnings
 from astropy import units
 from astropy.coordinates import Angle, SkyCoord, EarthLocation
 from pyuvdata import UVBeam, UVData
@@ -1002,6 +1001,9 @@ def test_moon_lsts():
     assert new_obj.check()
 
 
+@pytest.mark.filterwarnings("ignore:The _ra parameters are not")
+@pytest.mark.filterwarnings("ignore:The _dec parameters are not")
+@pytest.mark.filterwarnings("ignore:Future equality does not pass")
 def test_mock_catalog_moon():
     # A mock catalog made with a MoonLocation.
     pytest.importorskip('lunarsky')
@@ -1018,6 +1020,4 @@ def test_mock_catalog_moon():
     assert ekwds['world'] == 'earth'
 
     # Simple check that the given lat/lon were interpreted differently in each call.
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore')
-        assert mmock != emock
+    assert mmock != emock

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -9,15 +9,17 @@ import shutil
 import numpy as np
 import pytest
 import yaml
+import warnings
 from astropy import units
 from astropy.coordinates import Angle, SkyCoord, EarthLocation
-from astropy.time import Time
 from pyuvdata import UVBeam, UVData
 import pyradiosky
 
 import pyuvsim
 import pyuvsim.tests as simtest
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
+
+from pyuvsim.astropy_interface import Time
 
 herabeam_default = os.path.join(SIM_DATA_PATH, 'HERA_NicCST.uvbeam')
 
@@ -966,3 +968,56 @@ def test_beamopts_init():
     telconfig['spline_interp_opts'] = {'kx' : 2, 'ky' : 2}
     beam_list = pyuvsim.simsetup._construct_beam_list(np.arange(1), telconfig)
     assert beam_list.spline_interp_opts is not None
+
+
+def test_moon_lsts():
+    # Check that setting lsts for a Moon simulation works as expected.
+    pytest.importorskip('lunarsky')
+
+    param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'obsparam_tranquility_hex.yaml')
+    param_dict = pyuvsim.simsetup._config_str_to_dict(param_filename)
+    uv_obj, beam_list, beam_dict = pyuvsim.initialize_uvdata_from_params(param_dict)
+    assert 'world' in uv_obj.extra_keywords.keys()
+    assert uv_obj.extra_keywords['world'] == 'moon'
+
+    # Check ordering on lsts -- unique lsts should correspond with unique times.
+    lsts, lst_inds = np.unique(uv_obj.lst_array, return_inverse=True)
+    times, time_inds = np.unique(uv_obj.time_array, return_inverse=True)
+    assert np.all(lst_inds == time_inds)
+
+    # Confirm that the change in LST makes sense for a lunar month.
+    dlst = np.degrees(lsts[1] - lsts[0]) / 15 * 3600  # Hours per step.
+    tstep_per_lunar_month = 28 * 24 * 3600 / uv_obj.integration_time[0]
+    sec_per_tstep = 24 * 3600 / tstep_per_lunar_month
+
+    assert np.isclose(dlst, sec_per_tstep, rtol=1e-2)
+
+    # Unset the lst array and confirm that the call from _complete_uvdata returns the same.
+    backup_lst_array = uv_obj.lst_array.copy()
+    uv_obj.lst_array = None
+
+    new_obj = pyuvsim.simsetup._complete_uvdata(uv_obj)
+
+    assert np.allclose(new_obj.lst_array, backup_lst_array)
+    assert new_obj.check()
+
+
+def test_mock_catalog_moon():
+    # A mock catalog made with a MoonLocation.
+    pytest.importorskip('lunarsky')
+    import lunarsky
+    from pyuvsim.astropy_interface import Time
+
+    time = Time.now()
+    loc = lunarsky.MoonLocation.from_selenodetic(24.433333333, 0.687500000)
+    mmock, mkwds = pyuvsim.simsetup.create_mock_catalog(time, 'hera_text', array_location=loc)
+    eloc = EarthLocation.from_geodetic(24.433, 0.6875)
+    emock, ekwds = pyuvsim.simsetup.create_mock_catalog(time, 'hera_text', array_location=eloc)
+
+    assert mkwds['world'] == 'moon'
+    assert ekwds['world'] == 'earth'
+
+    # Simple check that the given lat/lon were interpreted differently in each call.
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        assert mmock != emock

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -12,7 +12,6 @@ from numpy.lib import recfunctions
 import pyuvdata.utils as uvutils
 from astropy import units
 from astropy.coordinates import Angle, SkyCoord, EarthLocation, Longitude, Latitude
-from astropy.time import Time
 import pytest
 from pyuvdata import UVData
 from pyuvdata.data import DATA_PATH

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -22,6 +22,7 @@ import pyuvsim
 import pyuvsim.tests as simtest
 import pyuvsim.utils as simutils
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
+from pyuvsim.astropy_interface import Time
 
 cst_files = ['HERA_NicCST_150MHz.txt', 'HERA_NicCST_123MHz.txt']
 beam_files = [os.path.join(DATA_PATH, 'NicCSTbeams', f) for f in cst_files]
@@ -938,3 +939,20 @@ def test_fullfreq_check(uvobj_beams_srcs):
         next(taskiter0)
 
     next(taskiter1)
+
+
+@pytest.mark.skipif('pyuvsim.astropy_interface.hasmoon')
+def test_moonloc_error(uvobj_beams_srcs):
+    # Break if the uvobj indicates that the sim is on the Moon, but lunarsky is not available.
+
+    uv_obj, beam_list, beam_dict, sources = uvobj_beams_srcs
+
+    uv_obj.extra_keywords['world'] = 'moon'
+
+    with pytest.raises(ValueError, match='Need lunarsky module to simulate'):
+        next(pyuvsim.uvsim.uvdata_to_task_iter(range(5), uv_obj, sources, beam_list, beam_dict))
+
+    uv_obj.extra_keywords['world'] = 'gallifrey'
+
+    with pytest.raises(ValueError, match="If world keyword is set, it must "):
+        next(pyuvsim.uvsim.uvdata_to_task_iter(range(5), uv_obj, sources, beam_list, beam_dict))

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -66,8 +66,7 @@ class progsteps:
                 print(("{:0.2f}% completed. {}  elapsed. "
                        + "{} remaining. \n").format(
                     frac_done * 100., str(timedelta(seconds=dt)),
-                    str(timedelta(seconds=self.remain))))
-                sys.stdout.flush()
+                    str(timedelta(seconds=self.remain))), flush=True)
 
     def finish(self):
         self.update(self.maxval)
@@ -217,7 +216,7 @@ def write_uvdata(uv_obj, param_dict, return_filename=False, dryrun=False, out_fo
     if noclobber:
         outfile_name = check_file_exists_and_increment(outfile_name)
 
-    print('Outfile path: ', outfile_name)
+    print('Outfile path: ', outfile_name, flush=True)
     if not dryrun:
         if out_format == 'uvfits':
             uv_obj.write_uvfits(outfile_name, force_phase=True, spoof_nonessential=True)

--- a/scripts/run_param_pyuvsim.py
+++ b/scripts/run_param_pyuvsim.py
@@ -15,6 +15,7 @@ parser = argparse.ArgumentParser(
 )
 parser.add_argument('paramsfile', type=str, help='Parameter yaml file.', default=None)
 parser.add_argument('--profile', type=str, help='Time profiling output file name.')
+parser.add_argument('--quiet', action='store_true', help='Suppress stdout printing.')
 parser.add_argument('--raw_profile', help='Also save pickled LineStats data for line profiling.',
                     action='store_true')
 
@@ -31,7 +32,7 @@ if not os.path.isdir(os.path.dirname(args.paramsfile)):
 
 t0 = pytime.time()
 
-pyuvsim.uvsim.run_uvsim(args.paramsfile)
+pyuvsim.uvsim.run_uvsim(args.paramsfile, quiet=args.quiet)
 
 if args.profile:
     dt = pytime.time() - t0

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,9 @@ setup_args = {
     'keywords': 'radio astronomy interferometry',
     'extras_require': {
         'sim': ['mpi4py>=3.0.0', 'psutil'],
-        'all': ['mpi4py>=3.0.0', 'psutil', 'line_profiler'],
+        'all': ['mpi4py>=3.0.0', 'psutil', 'line_profiler', 'lunarsky'],
         'dev': ['mpi4py>=3.0.0', 'psutil', 'line_profiler', 'pypandoc',
-                'pytest', 'pytest-cov', 'sphinx', 'pre-commit']
+                'pytest', 'pytest-cov', 'sphinx', 'pre-commit', 'lunarsky']
     }
 }
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup_args = {
     'extras_require': {
         'sim': ['mpi4py>=3.0.0', 'psutil'],
         'all': ['mpi4py>=3.0.0', 'psutil', 'line_profiler', 'lunarsky'],
+        'moon': ['mpi4py>=3.0.0', 'psutil', 'lunarsky'],
         'dev': ['mpi4py>=3.0.0', 'psutil', 'line_profiler', 'pypandoc',
                 'pytest', 'pytest-cov', 'sphinx', 'pre-commit', 'lunarsky']
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Provides compatibility with the `lunarsky` module, if installed. If the keyword "world: moon" is in the telescope config yaml file, the `telescope_location` will be interpreted as a lat/lon/height position for an observatory on the Moon. The output UVData object has `extra_keyword['world'] = moon` to identify when this was done.

There are also a few docstring updates, and the addition of a "quiet" option to suppress stdout printing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It has been a long-standing issue to allow pyuvsim to simulate observations from the lunar surface for the FARSIDE experiment. The `lunarsky` module provides an extension to `astropy`'s coordinate classes, using the JPL SPICE toolkit to calculate transformations to and from lunar reference frames. `pyradiosky` already support `lunarsky`. These changes extend support to `pyuvsim`.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #5 

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the documentation to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass in both python 2 and python 3.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).