### PR TITLE
SkyModelData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Benchmarking tools.
 
 ### Changed
+- Use `at_frequencies` method to enable support for all pyradiosky spectral types.
 - Only do coherency calculation when the time changes
 - Only do beam eval when time, freq, or beam type changes.
 - The definition of the Airy beam now uses the exact value of c, not 3e8.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
 ### Added
+- quantity_shared_bcast function to allow objects derived from astropy.units.Quantity to use shared memory broadcasting.
+- SkyModelData class to replace recarray conversion in pyradiosky.
 - quiet keyword for run_uvsim, to suppress stdout printing.
 - Support for Moon-based observing -- keyword "world: moon" in telescope config.
 - Option to pass along interpolating spline order to UVBeam from teleconfig file.

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -10,6 +10,7 @@ dependencies:
   - mpi4py>=3.0.0
   - numpy>=1.15
   - pip
+  - astropy-healpix
   - psutil
   - pytest
   - pytest-cov

--- a/pyuvsim/data/bl_lite_mixed.yaml
+++ b/pyuvsim/data/bl_lite_mixed.yaml
@@ -1,0 +1,16 @@
+beam_paths:
+  0: hera.uvbeam
+  1:
+    type: airy
+    diameter: 16
+  2:
+    type: gaussian
+    sigma: 0.03
+  3: airy
+diameter: 12
+spline_interp_opts:
+        kx: 4
+        ky: 4
+freq_interp_kind: 'cubic'
+telescope_location: (-30.72152777777791, 21.428305555555557, 1073.0000000093132)
+telescope_name: BLLITE

--- a/pyuvsim/data/test_config/param_10time_10chan_5.yaml
+++ b/pyuvsim/data/test_config/param_10time_10chan_5.yaml
@@ -2,9 +2,6 @@ filing:
   outfile_prefix: 'sim'
   outfile_suffix: 'results'
 freq:
-        #  channel_width:  80000.0
-        #  end_freq:   100760000.0
-        #  start_freq: 100040000.0
   channel_width:  1.0
   end_freq:   109.5
   start_freq: 100.5

--- a/pyuvsim/mpi.py
+++ b/pyuvsim/mpi.py
@@ -99,8 +99,8 @@ def shared_mem_bcast(arr, root=0):
     if node_comm.rank == root:
         # Data cannot be shared between nodes.
         # Need to broadcast to the root process on each node.
-        dtype = arr.dtype
         arr = big_bcast(rank_comm, arr, root=root)
+        dtype = arr.dtype
         Nitems = arr.size
         shape = arr.shape
         itemsize = sys.getsizeof(arr.flatten()[0])

--- a/pyuvsim/mpi.py
+++ b/pyuvsim/mpi.py
@@ -76,8 +76,20 @@ def shared_mem_bcast(arr, root=0):
 
     Must be called from all PUs, but only the root process
     should pass in an array. Every other process should pass in None.
-    """
 
+    Parameters
+    ----------
+
+    arr: ndarray
+        Data to be shared.
+    root: int
+        Root rank on COMM_WORLD, from which data will be broadcast.
+
+    Notes
+    -----
+    Data will be duplicated once per node, but will be shared among
+    processes on each node.
+    """
     nbytes = 0
     itemsize = 0
     dtype = None
@@ -85,13 +97,13 @@ def shared_mem_bcast(arr, root=0):
     shape = tuple()  # noqa
 
     if node_comm.rank == root:
-        # Data cannot be shared across nodes.
-        # Need to broadcast to the root PU on each node.
+        # Data cannot be shared between nodes.
+        # Need to broadcast to the root process on each node.
+        dtype = arr.dtype
         arr = big_bcast(rank_comm, arr, root=root)
         Nitems = arr.size
         shape = arr.shape
         itemsize = sys.getsizeof(arr.flatten()[0])
-        dtype = arr.dtype
         nbytes = itemsize * Nitems
 
     itemsize = node_comm.bcast(itemsize, root=root)
@@ -111,10 +123,35 @@ def shared_mem_bcast(arr, root=0):
         # Now fill the window on each node with the data.
         sh_arr[:] = arr[()]
 
-    sh_arr.flags['WRITEABLE'] = False  # Do not want ranks overwriting the data.
+    # Access is not synchronized, so no process
+    # should be allowed to overwrite.
+    sh_arr.flags['WRITEABLE'] = False
 
     world_comm.Barrier()
     return sh_arr
+
+
+def quantity_shared_bcast(obj, root=0):
+    """
+    Broadcast to shared memory for classes derived from astropy.units.Quantity.
+
+    The value array will be in shared memory, but the handle to it on each process
+    will be a Quantity, Angle, Latitude, Longitude, etc.
+    """
+
+    unit = None
+    sclass = None
+    value = None
+    if world_comm.rank == root:
+        sclass = obj.__class__
+        unit = obj.unit
+        value = obj.value
+
+    value = shared_mem_bcast(value, root=root)
+    sclass = world_comm.bcast(sclass, root=root)
+    unit = world_comm.bcast(unit, root=root)
+
+    return sclass(value, copy=False, unit=unit)
 
 
 def big_bcast(comm, objs, root=0, return_split_info=False, MAX_BYTES=INT_MAX):
@@ -133,7 +170,7 @@ def big_bcast(comm, objs, root=0, return_split_info=False, MAX_BYTES=INT_MAX):
         Rank of process to receive the data.
     return_split_info: bool
         On root process, also a return a dictionary describing
-        how the data were split.
+        how the data were split. Used for testing.
     MAX_BYTES: int
         Maximum bytes per chunk.
         Defaults to the INT_MAX of 32 bit integers. Used for testing.
@@ -152,39 +189,55 @@ def big_bcast(comm, objs, root=0, return_split_info=False, MAX_BYTES=INT_MAX):
     Notes
     -----
     Running this on MPI.COMM_WORLD means that every process gets a full copy of
-    `objs`. This is mainly used in pyuvsim to send large data once to each node, to be
-    put in shared memory.
+    `objs`, potentially using up available memory. This function is currently used
+    to send large data once to each node, to be put in shared memory.
     """
-    bytesize = None
+    bufsize = None
+    nopickle = False
+    shape = None
+    dtype = None
     if comm.rank == root:
-        buf = dumps(objs)
-        bytesize = len(buf)
+        if isinstance(objs, np.ndarray):
+            shape = objs.shape
+            dtype = objs.dtype
+            buf = objs.tobytes()
+            nopickle = True
+        else:
+            buf = dumps(objs)
+        bufsize = len(buf)
 
     # Sizes of send buffers to be sent from each rank.
-    bytesize = comm.bcast(bytesize, root=root)
+    bufsize = comm.bcast(bufsize, root=root)
+    nopickle = comm.bcast(nopickle, root=root)
+    if nopickle:
+        shape = comm.bcast(shape, root=root)
+        dtype = comm.bcast(dtype, root=root)
+
     if comm.rank != root:
-        buf = np.empty(bytesize, dtype=bytes)
+        buf = np.empty(bufsize, dtype=bytes)
 
     # Ranges of output bytes for each chunk.
     start = 0
     end = 0
     ranges = []
-    while end < bytesize:
-        end = min(start + MAX_BYTES, bytesize)
+    while end < bufsize:
+        end = min(start + MAX_BYTES, bufsize)
         ranges.append((start, end))
         start += MAX_BYTES
 
     for start, end in ranges:
         comm.Bcast([buf[start:end], MPI.BYTE], root=root)
-
-    result = loads(buf)
+    if nopickle:
+        result = np.frombuffer(buf, dtype=dtype)
+        result = result.reshape(shape)
+    else:
+        result = loads(buf)
 
     if comm.rank == root:
         split_info_dict = {'MAX_BYTES': MAX_BYTES, 'ranges': ranges}
 
     if return_split_info:
         return result, split_info_dict
-
     return result
 
 
@@ -219,7 +272,7 @@ def big_gather(comm, objs, root=0, return_split_info=False, MAX_BYTES=INT_MAX):
     Returns
     -------
     list of objects:
-        Length Npus list, such that the n'th entry is the data gathered from
+        Length Npus, such that the n'th entry is the data gathered from
         the n'th process.
         This is only filled on the root process. Other processes get None.
     dict:

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -639,8 +639,9 @@ def initialize_catalog_from_params(obs_params, input_uv=None, return_recarray=Tr
 
     # Make SkyModelData to share it.
     if return_recarray:
-        warnings.warn("initialize_catalog_from_params will not "
-                      "return recarray by default in the future.", PendingDeprecationWarning)
+        warnings.warn("initialize_catalog_from_params will return a SkyModel instance, not "
+                      "a recarray, by default in the future. Set keyword "
+                      "`return_recarray=True` to ensure recarray is returned.", PendingDeprecationWarning)
         sky = sky.to_recarray()
 
     return sky, source_list_name

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -641,7 +641,8 @@ def initialize_catalog_from_params(obs_params, input_uv=None, return_recarray=Tr
     if return_recarray:
         warnings.warn("initialize_catalog_from_params will return a SkyModel instance, not "
                       "a recarray, by default in the future. Set keyword "
-                      "`return_recarray=True` to ensure recarray is returned.", PendingDeprecationWarning)
+                      "`return_recarray=True` to ensure recarray is returned.",
+                      PendingDeprecationWarning)
         sky = sky.to_recarray()
 
     return sky, source_list_name

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -515,12 +515,12 @@ def initialize_catalog_from_params(obs_params, input_uv=None, return_recarray=Tr
     input_uv: :class:~`pyuvdata.UVData`
         Used to set location for mock catalogs and for horizon cuts.
     return_recarray: bool
-        Return a recarray instead of a :class:~`pyuvsim.simsetup.SkyModelData` instance.
+        Return a recarray instead of a :class:~`pyradiosky.SkyModel` instance.
         Default is True.
 
     Returns
     -------
-    skydata: numpy.recarray or :class:~`pyuvsim.simsetup.SkyModelData`
+    skydata: numpy.recarray or :class:~`pyradiosky.SkyModel`
         Source catalog filled with data.
     source_list_name: str
             Catalog identifier for metadata.
@@ -641,11 +641,9 @@ def initialize_catalog_from_params(obs_params, input_uv=None, return_recarray=Tr
     if return_recarray:
         warnings.warn("initialize_catalog_from_params will not "
                       "return recarray by default in the future.", PendingDeprecationWarning)
-        skydata = sky.to_recarray()
-    else:
-        skydata = SkyModelData(sky)
+        sky = sky.to_recarray()
 
-    return skydata, source_list_name
+    return sky, source_list_name
 
 
 def _construct_beam_list(beam_ids, telconfig):

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -409,6 +409,7 @@ class SkyModelData:
         if self.freq_array is not None:
             new_sky.freq_array = self.freq_array
         if self.hpx_inds is not None:
+            print("hello", flush=True)
             new_sky.hpx_inds = self.hpx_inds[inds]
 
         if self.polarized is not None:

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -347,11 +347,15 @@ class SkyModelData:
             self.ra = sky_in.ra.deg
             self.dec = sky_in.dec.deg
             self.Nfreqs = sky_in.Nfreqs
-            self.stokes_I = sky_in.stokes[0, ...]
+            stokes_in = sky_in.stokes
+
+            if isinstance(stokes_in, units.Quantity):
+                stokes_in = stokes_in.to('Jy').value
+            self.stokes_I = stokes_in[0, ...]
 
             if sky_in._n_polarized > 0:
                 self.polarized = sky_in._polarized
-                Q, U, V = sky_in.stokes[1:, :, sky_in._polarized]
+                Q, U, V = stokes_in[1:, :, sky_in._polarized]
                 self.stokes_Q = Q
                 self.stokes_U = U
                 self.stokes_V = V
@@ -470,6 +474,9 @@ class SkyModelData:
             stokes_use[1, :, self.polarized] = self.stokes_Q.T
             stokes_use[2, :, self.polarized] = self.stokes_U.T
             stokes_use[3, :, self.polarized] = self.stokes_V.T
+
+        if units.Quantity in pyradiosky.SkyModel()._stokes.expected_type:
+            stokes_use *= units.Jy
 
         other = {}
         if self.spectral_type in ['full', 'subband']:

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -502,7 +502,7 @@ class SkyModelData:
         )
 
 
-def initialize_catalog_from_params(obs_params, input_uv=None):
+def initialize_catalog_from_params(obs_params, input_uv=None, return_recarray=True):
     """
     Make catalog from parameter file specifications.
 
@@ -514,10 +514,13 @@ def initialize_catalog_from_params(obs_params, input_uv=None):
         Either an obsparam file name or a dictionary of parameters.
     input_uv: :class:~`pyuvdata.UVData`
         Used to set location for mock catalogs and for horizon cuts.
+    return_recarray: bool
+        Return a recarray instead of a :class:~`pyuvsim.simsetup.SkyModelData` instance.
+        Default is True.
 
     Returns
     -------
-    skydata: :class:~`pyuvsim.simsetup.SkyModelData`
+    skydata: numpy.recarray or :class:~`pyuvsim.simsetup.SkyModelData`
         Source catalog filled with data.
     source_list_name: str
             Catalog identifier for metadata.
@@ -635,7 +638,12 @@ def initialize_catalog_from_params(obs_params, input_uv=None):
     sky.source_cuts(**source_select_kwds)
 
     # Make SkyModelData to share it.
-    skydata = SkyModelData(sky)
+    if return_recarray:
+        warnings.warn("initialize_catalog_from_params will not "
+                      "return recarray by default in the future.", PendingDeprecationWarning)
+        skydata = sky.to_recarray()
+    else:
+        skydata = SkyModelData(sky)
 
     return skydata, source_list_name
 

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -345,9 +345,10 @@ class SkyModelData:
 
             self.polarized = sky_in._polarized
             if sky_in._n_polarized > 0:
-                self.stokes_Q = sky_in.stokes[1, :, sky_in._polarized]
-                self.stokes_U = sky_in.stokes[2, :, sky_in._polarized]
-                self.stokes_V = sky_in.stokes[3, :, sky_in._polarized]
+                Q, U, V = sky_in.stokes[1:, :, sky_in._polarized]
+                self.stokes_Q = Q
+                self.stokes_U = U
+                self.stokes_V = V
 
             if sky_in._freq_array.required:
                 self.freq_array = sky_in.freq_array.to("Hz").value
@@ -444,7 +445,6 @@ class SkyModelData:
             )
             sel_in_pol = [ii for ii, pi in enumerate(self.polarized) if pi in comp_sel]
             if len(sel_in_pol) > 0:
-                # For some reason, the index array on stokes_use causes the axes to flip...
                 stokes_use[1, :, pol_in_sel] = self.stokes_Q[:, sel_in_pol].T
                 stokes_use[2, :, pol_in_sel] = self.stokes_U[:, sel_in_pol].T
                 stokes_use[3, :, pol_in_sel] = self.stokes_V[:, sel_in_pol].T

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -352,10 +352,10 @@ class SkyModelData:
 
             if isinstance(stokes_in, units.Quantity):
                 if stokes_in.unit.is_equivalent("Jy"):
-                    stokes_in = stokes_in.to("Jy").value
+                    stokes_in = stokes_in.to_value("Jy")
                     self.flux_unit = "Jy"
                 elif stokes_in.unit.is_equivalent("K"):
-                    stokes_in = stokes_in.to("K").value
+                    stokes_in = stokes_in.to_value("K")
                     self.flux_unit = "K"
 
             self.stokes_I = stokes_in[0, ...]

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -579,10 +579,11 @@ def initialize_catalog_from_params(obs_params, input_uv=None):
         source_list_name = 'mock_' + "_".join(mock_keyvals)
     elif isinstance(catalog, str):
         source_list_name = os.path.basename(catalog)
+        sky = pyradiosky.SkyModel()
         if not os.path.isfile(catalog):
             catalog = os.path.join(param_dict['config_path'], catalog)
         if catalog.endswith("txt"):
-            sky = pyradiosky.read_text_catalog(catalog)
+            sky.read_text_catalog(catalog)
         elif catalog.endswith('vot'):
             if 'gleam' in catalog:
                 if "spectral_type" in source_params:
@@ -590,7 +591,7 @@ def initialize_catalog_from_params(obs_params, input_uv=None):
                 else:
                     warnings.warn("No spectral_type specified for GLEAM, using 'flat'.")
                     spectral_type = "flat"
-                sky = pyradiosky.skymodel.read_gleam_catalog(
+                sky.read_gleam_catalog(
                     catalog, spectral_type=spectral_type
                 )
             else:
@@ -606,20 +607,19 @@ def initialize_catalog_from_params(obs_params, input_uv=None):
                 vo_params["flux_columns"] = source_params["flux_columns"]
                 if "ra_column" not in source_params:
                     warnings.warn(f"No RA column name specified for {catalog}, using default.")
+                    vo_params["ra_column"] = "RAJ2000"
                 else:
                     vo_params["ra_column"] = source_params["ra_column"]
                 if "dec_column" not in source_params:
                     warnings.warn(f"No Dec column name specified for {catalog}, using default.")
+                    vo_params["dec_column"] = "DEJ2000"
                 else:
                     vo_params["dec_column"] = source_params["dec_column"]
 
                 vo_params["reference_frequency"] = None
-                sky = pyradiosky.read_votable_catalog(
-                    catalog, **vo_params
-                )
+                sky.read_votable_catalog(catalog, **vo_params)
         elif catalog.endswith('hdf5'):
-            hpmap, inds, freqs = pyradiosky.read_healpix_hdf5(catalog)
-            sky = pyradiosky.healpix_to_sky(hpmap, inds, freqs)
+            sky.read_healpix_hdf5(catalog)
 
     # Do source selections, if any.
     if input_uv is not None:

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -415,14 +415,13 @@ class SkyModelData:
                               "Install it by running pip install pyuvsim[sim] "
                               "or pip install pyuvsim[all] if you also want the "
                               "line_profiler installed.")
-        mpi.start_mpi(False)
+        mpi.start_mpi()
         self.Ncomponents = mpi.world_comm.bcast(self.Ncomponents, root=root)
 
         # Get list of attributes that are set.
         isset = None
         if mpi.rank == root:
             isset = [key for key, value in self.__dict__.items() if value is not None]
-
         isset = mpi.world_comm.bcast(isset, root=root)
 
         for key in isset:

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -433,7 +433,7 @@ class SkyModelData:
         All attributes are put in shared memory.
         """
         if mpi is None:
-            raise ImportError("You need mpi4py to use the this method. "
+            raise ImportError("You need mpi4py to use this method. "
                               "Install it by running pip install pyuvsim[sim] "
                               "or pip install pyuvsim[all] if you also want the "
                               "line_profiler installed.")

--- a/pyuvsim/tests/conftest.py
+++ b/pyuvsim/tests/conftest.py
@@ -47,3 +47,6 @@ def setup_and_teardown_package():
 def ignore_deprecation():
     warnings.filterwarnings('ignore', message='Achromatic gaussian beams will not be supported',
                             category=PendingDeprecationWarning)
+    warnings.filterwarnings('ignore', message='"initialize_catalog_from_params will not return'
+                                              ' recarray by default in the future.',
+                            category=PendingDeprecationWarning)

--- a/pyuvsim/tests/test_analyticbeam.py
+++ b/pyuvsim/tests/test_analyticbeam.py
@@ -126,7 +126,7 @@ def test_uv_beam_widths():
 
 
 def test_achromatic_gaussian_beam():
-    sigma_rad = Angle('5d').to('rad').value
+    sigma_rad = Angle('5d').to_value('rad')
     beam = pyuvsim.AnalyticBeam('gaussian', sigma=sigma_rad)
     beam.peak_normalize()
     beam.interpolation_function = 'az_za_simple'
@@ -201,7 +201,7 @@ def test_gaussbeam_values():
     altitudes = task.sources.alt_az[0]  # In radians.
     # All four components should be identical
     if isinstance(engine.apparent_coherency, units.Quantity):
-        coherency_use = engine.apparent_coherency.to("Jy").value
+        coherency_use = engine.apparent_coherency.to_value("Jy")
     else:
         coherency_use = engine.apparent_coherency
 

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -170,9 +170,10 @@ def test_gleam_catalog():
     param_dict["sources"].pop("min_flux")
     param_dict["sources"].pop("max_flux")
 
-    gleam_catalog = (
-        pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
-    ).get_skymodel()
+    with pytest.warns(UserWarning, match="No spectral_type specified for GLEAM, using 'flat'."):
+        gleam_catalog = (
+            pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
+        ).get_skymodel()
     assert gleam_catalog.Ncomponents == 50
 
 
@@ -843,8 +844,9 @@ def test_mock_catalogs():
     with pytest.raises(KeyError, match="Invalid mock catalog arrangement: invalid_catalog_name"):
         pyuvsim.create_mock_catalog(time, 'invalid_catalog_name')
 
+    radec_catalog = pyradiosky.SkyModel()
     for arr in arrangements:
-        radec_catalog = pyradiosky.read_text_catalog(
+        radec_catalog.read_text_catalog(
             os.path.join(SIM_DATA_PATH, 'test_catalogs', text_catalogs[arr])
         )
         assert np.all(radec_catalog == cats[arr])

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -112,7 +112,7 @@ def test_catalog_from_params():
         pyuvsim.simsetup.initialize_catalog_from_params({'sources': source_dict})
 
     catalog_uv, srclistname = pyuvsim.simsetup.initialize_catalog_from_params(
-        {'sources': source_dict}, hera_uv
+        {'sources': source_dict}, hera_uv, return_recarray=False
     )
     catalog_uv = catalog_uv.get_skymodel()
     source_dict['array_location'] = arrloc
@@ -130,7 +130,7 @@ def test_catalog_from_params():
         match="Warning: No julian date given for mock catalog. Defaulting to first time step."
     ):
         catalog_str, srclistname2 = pyuvsim.simsetup.initialize_catalog_from_params(
-            {'sources': source_dict}, hera_uv
+            {'sources': source_dict}, hera_uv, return_recarray=False
         )
 
     catalog_str = catalog_str.get_skymodel()
@@ -140,12 +140,16 @@ def test_catalog_from_params():
 def test_vot_catalog():
     vot_param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testvot.yaml')
     vot_catalog = (
-        pyuvsim.simsetup.initialize_catalog_from_params(vot_param_filename)[0]
+        pyuvsim.simsetup.initialize_catalog_from_params(
+            vot_param_filename, return_recarray=False
+        )[0]
     ).get_skymodel()
 
     txt_param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testcat.yaml')
     txt_catalog = (
-        pyuvsim.simsetup.initialize_catalog_from_params(txt_param_filename)[0]
+        pyuvsim.simsetup.initialize_catalog_from_params(
+            txt_param_filename, return_recarray=False
+        )[0]
     ).get_skymodel()
 
     assert vot_catalog == txt_catalog
@@ -157,7 +161,9 @@ def test_gleam_catalog():
     )
     with pytest.warns(UserWarning, match="No spectral_type specified for GLEAM, using 'flat'."):
         gleam_catalog = (
-            pyuvsim.simsetup.initialize_catalog_from_params(gleam_param_filename)[0]
+            pyuvsim.simsetup.initialize_catalog_from_params(
+                gleam_param_filename, return_recarray=False
+            )[0]
         ).get_skymodel()
 
     # flux cuts applied
@@ -172,7 +178,7 @@ def test_gleam_catalog():
 
     with pytest.warns(UserWarning, match="No spectral_type specified for GLEAM, using 'flat'."):
         gleam_catalog = (
-            pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
+            pyuvsim.simsetup.initialize_catalog_from_params(param_dict, return_recarray=False)[0]
         ).get_skymodel()
     assert gleam_catalog.Ncomponents == 50
 
@@ -184,7 +190,9 @@ def test_healpix_catalog():
     sky.read_healpix_hdf5(path)
 
     params = {'sources': {'catalog': path}}
-    hpx_skymodeldata = pyuvsim.simsetup.initialize_catalog_from_params(params)[0]
+    hpx_skymodeldata = pyuvsim.simsetup.initialize_catalog_from_params(
+        params, return_recarray=False
+    )[0]
     hpx_sky = hpx_skymodeldata.get_skymodel()
     assert hpx_sky == sky
 
@@ -203,7 +211,9 @@ def test_gleam_catalog_spectral_type(spectral_type):
     param_dict["sources"].pop("max_flux")
     param_dict["sources"]["spectral_type"] = spectral_type
 
-    gleam_catalog = pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
+    gleam_catalog = pyuvsim.simsetup.initialize_catalog_from_params(
+        param_dict, return_recarray=False
+    )[0]
     assert gleam_catalog.spectral_type == spectral_type
     assert gleam_catalog.Ncomponents == 50
 
@@ -216,7 +226,9 @@ def test_vot_catalog_warns(key_pop, message):
     vot_param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testvot.yaml')
 
     vot_catalog = (
-        pyuvsim.simsetup.initialize_catalog_from_params(vot_param_filename)[0]
+        pyuvsim.simsetup.initialize_catalog_from_params(
+            vot_param_filename, return_recarray=False
+        )[0]
     ).get_skymodel()
 
     with open(vot_param_filename, 'r') as pfile:
@@ -226,7 +238,7 @@ def test_vot_catalog_warns(key_pop, message):
 
     with pytest.warns(UserWarning, match=message):
         vot_catalog2 = (
-            pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
+            pyuvsim.simsetup.initialize_catalog_from_params(param_dict, return_recarray=False)[0]
         ).get_skymodel()
 
     assert vot_catalog == vot_catalog2
@@ -246,7 +258,7 @@ def test_vot_catalog_error(key_pop, message):
     param_dict["sources"].pop(key_pop)
 
     with pytest.raises(ValueError, match=message):
-        pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
+        pyuvsim.simsetup.initialize_catalog_from_params(param_dict, return_recarray=False)[0]
 
 
 @pytest.mark.parametrize("config_num", [0, 2])

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1083,19 +1083,20 @@ def cat_with_some_pols():
     return sky
 
 
-def test_skymodeldata_with_quantity_stokes(cat_with_some_pols):
+@pytest.mark.parametrize('unit', ['Jy', 'K'])
+def test_skymodeldata_with_quantity_stokes(unit, cat_with_some_pols):
     # Support for upcoming pyradiosky change setting SkyModel.stokes
     # to an astropy Quantity.
     sky = cat_with_some_pols
     if not isinstance(sky.stokes, units.Quantity):
-        sky.stokes *= units.Jy
+        sky.stokes *= units.Unit(unit)
 
     smd = pyuvsim.simsetup.SkyModelData(sky)
-    assert np.all(sky.stokes.to('Jy').value[0] == smd.stokes_I)
+    assert np.all(sky.stokes.to(unit).value[0] == smd.stokes_I)
 
     sky2 = smd.get_skymodel()
     if units.Quantity != pyradiosky.SkyModel()._stokes.expected_type:
-        sky.stokes = sky.stokes.to("Jy").value
+        sky.stokes = sky.stokes.to(unit).value
     assert sky2 == sky
 
 

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1095,6 +1095,23 @@ def cat_with_some_pols():
     return sky
 
 
+def test_skymodeldata_with_quantity_stokes(cat_with_some_pols):
+    # Support for upcoming pyradiosky change setting SkyModel.stokes
+    # to an astropy Quantity.
+    sky = cat_with_some_pols
+    unit = 'Jy'
+    if not isinstance(sky.stokes, units.Quantity):
+        sky.stokes *= units.Unit(unit)
+
+    smd = pyuvsim.simsetup.SkyModelData(sky)
+    assert np.all(sky.stokes.to(unit).value[0] == smd.stokes_I)
+
+    sky2 = smd.get_skymodel()
+    if units.Quantity != pyradiosky.SkyModel()._stokes.expected_type:
+        sky.stokes = sky.stokes.to(unit).value
+    assert sky2 == sky
+
+
 @pytest.mark.parametrize('component_type', ['point', 'healpix'])
 def test_skymodeldata(component_type, cat_with_some_pols):
     # Test that SkyModelData class can properly recreate a SkyModel and subselect.

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -113,7 +113,7 @@ def test_catalog_from_params():
     catalog_uv, srclistname = pyuvsim.simsetup.initialize_catalog_from_params(
         {'sources': source_dict}, hera_uv
     )
-    catalog_uv = pyradiosky.array_to_skymodel(catalog_uv)
+    catalog_uv = catalog_uv.get_skymodel()
     source_dict['array_location'] = arrloc
     del source_dict['time']
 
@@ -132,33 +132,32 @@ def test_catalog_from_params():
             {'sources': source_dict}, hera_uv
         )
 
-    catalog_str = pyradiosky.array_to_skymodel(catalog_str)
+    catalog_str = catalog_str.get_skymodel()
     assert np.all(catalog_str == catalog_uv)
 
 
 def test_vot_catalog():
     vot_param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testvot.yaml')
-    vot_catalog = pyradiosky.array_to_skymodel(
+    vot_catalog = (
         pyuvsim.simsetup.initialize_catalog_from_params(vot_param_filename)[0]
-    )
+    ).get_skymodel()
 
     txt_param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testcat.yaml')
-    txt_catalog = pyradiosky.array_to_skymodel(
+    txt_catalog = (
         pyuvsim.simsetup.initialize_catalog_from_params(txt_param_filename)[0]
-    )
+    ).get_skymodel()
 
     assert vot_catalog == txt_catalog
 
 
-@pytest.mark.filterwarnings("ignore:The frequency field is included in the recarray")
 def test_gleam_catalog():
     gleam_param_filename = os.path.join(
         SIM_DATA_PATH, 'test_config', 'param_1time_1src_testgleam.yaml'
     )
     with pytest.warns(UserWarning, match="No spectral_type specified for GLEAM, using 'flat'."):
-        gleam_catalog = pyradiosky.array_to_skymodel(
+        gleam_catalog = (
             pyuvsim.simsetup.initialize_catalog_from_params(gleam_param_filename)[0]
-        )
+        ).get_skymodel()
 
     # flux cuts applied
     assert gleam_catalog.Ncomponents == 23
@@ -170,9 +169,9 @@ def test_gleam_catalog():
     param_dict["sources"].pop("min_flux")
     param_dict["sources"].pop("max_flux")
 
-    gleam_catalog = pyradiosky.array_to_skymodel(
+    gleam_catalog = (
         pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
-    )
+    ).get_skymodel()
     assert gleam_catalog.Ncomponents == 50
 
 
@@ -190,9 +189,7 @@ def test_gleam_catalog_spectral_type(spectral_type):
     param_dict["sources"].pop("max_flux")
     param_dict["sources"]["spectral_type"] = spectral_type
 
-    gleam_catalog = pyradiosky.array_to_skymodel(
-        pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
-    )
+    gleam_catalog = pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
     assert gleam_catalog.spectral_type == spectral_type
     assert gleam_catalog.Ncomponents == 50
 
@@ -204,9 +201,9 @@ def test_gleam_catalog_spectral_type(spectral_type):
 def test_vot_catalog_warns(key_pop, message):
     vot_param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testvot.yaml')
 
-    vot_catalog = pyradiosky.array_to_skymodel(
+    vot_catalog = (
         pyuvsim.simsetup.initialize_catalog_from_params(vot_param_filename)[0]
-    )
+    ).get_skymodel()
 
     with open(vot_param_filename, 'r') as pfile:
         param_dict = yaml.safe_load(pfile)
@@ -214,9 +211,9 @@ def test_vot_catalog_warns(key_pop, message):
     param_dict["sources"].pop(key_pop)
 
     with pytest.warns(UserWarning, match=message):
-        vot_catalog2 = pyradiosky.array_to_skymodel(
+        vot_catalog2 = (
             pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
-        )
+        ).get_skymodel()
 
     assert vot_catalog == vot_catalog2
 
@@ -235,9 +232,7 @@ def test_vot_catalog_error(key_pop, message):
     param_dict["sources"].pop(key_pop)
 
     with pytest.raises(ValueError, match=message):
-        pyradiosky.array_to_skymodel(
-            pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
-        )
+        pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
 
 
 # parametrize will loop over all the give values
@@ -258,7 +253,7 @@ def test_param_reader(config_num):
         hera_uv.select(bls=[(0, 1), (1, 2)])
 
     time = Time(hera_uv.time_array[0], scale='utc', format='jd')
-    sources, _ = pyuvsim.create_mock_catalog(time, arrangement='zenith', return_table=True)
+    sources, _ = pyuvsim.create_mock_catalog(time, arrangement='zenith', return_data=True)
 
     beam0 = UVBeam()
     beam0.read_beamfits(herabeam_default)

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -178,6 +178,7 @@ def test_gleam_catalog():
 
 
 def test_healpix_catalog():
+    pytest.importorskip('astropy_healpix')
     path = os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
     sky = pyradiosky.SkyModel()
     sky.read_healpix_hdf5(path)

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1049,6 +1049,20 @@ def cat_with_some_pols():
     return sky
 
 
+@pytest.mark.skipif("units.Quantity not in pyradiosky.SkyModel()._stokes.expected_type")
+def test_skymodeldata_with_quantity_stokes(cat_with_some_pols):
+    # Support for upcoming pyradiosky change setting SkyModel.stokes
+    # to an astropy Quantity.
+    sky = cat_with_some_pols
+    sky.stokes *= units.Jy
+
+    smd = pyuvsim.simsetup.SkyModelData(sky)
+    assert np.all(sky.stokes.to('Jy').value[0] == smd.stokes_I)
+
+    sky2 = smd.get_skymodel()
+    assert sky2 == sky
+
+
 @pytest.mark.parametrize('component_type', ['point', 'healpix'])
 def test_skymodeldata(component_type, cat_with_some_pols):
     # Test that SkyModelData class can properly recreate a SkyModel and subselect.

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1099,11 +1099,11 @@ def test_skymodeldata_with_quantity_stokes(cat_with_some_pols):
         sky.stokes *= units.Unit(unit)
 
     smd = pyuvsim.simsetup.SkyModelData(sky)
-    assert np.all(sky.stokes.to(unit).value[0] == smd.stokes_I)
+    assert np.all(sky.stokes.to_value(unit)[0] == smd.stokes_I)
 
     sky2 = smd.get_skymodel()
     if units.Quantity != pyradiosky.SkyModel()._stokes.expected_type:
-        sky.stokes = sky.stokes.to(unit).value
+        sky.stokes = sky.stokes.to_value(unit)
     assert sky2 == sky
 
 

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1055,6 +1055,7 @@ def test_skymodeldata(component_type, cat_with_some_pols):
     if component_type == 'point':
         sky = cat_with_some_pols
     else:
+        pytest.importorskip('astropy-healpix')
         path = os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
         sky = pyradiosky.SkyModel()
         sky.read_healpix_hdf5(path)

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1051,7 +1051,6 @@ def cat_with_some_pols():
     return sky
 
 
-@pytest.mark.skipif("units.Quantity not in pyradiosky.SkyModel()._stokes.expected_type")
 def test_skymodeldata_with_quantity_stokes(cat_with_some_pols):
     # Support for upcoming pyradiosky change setting SkyModel.stokes
     # to an astropy Quantity.
@@ -1062,6 +1061,8 @@ def test_skymodeldata_with_quantity_stokes(cat_with_some_pols):
     assert np.all(sky.stokes.to('Jy').value[0] == smd.stokes_I)
 
     sky2 = smd.get_skymodel()
+    if units.Quantity not in pyradiosky.SkyModel()._stokes.expected_type:
+        sky.stokes = sky.stokes.to("Jy").value
     assert sky2 == sky
 
 
@@ -1071,7 +1072,7 @@ def test_skymodeldata(component_type, cat_with_some_pols):
     if component_type == 'point':
         sky = cat_with_some_pols
     else:
-        pytest.importorskip('astropy-healpix')
+        pytest.importorskip('astropy_healpix')
         path = os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
         sky = pyradiosky.SkyModel()
         sky.read_healpix_hdf5(path)

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1055,13 +1055,14 @@ def test_skymodeldata_with_quantity_stokes(cat_with_some_pols):
     # Support for upcoming pyradiosky change setting SkyModel.stokes
     # to an astropy Quantity.
     sky = cat_with_some_pols
-    sky.stokes *= units.Jy
+    if not isinstance(sky.stokes, units.Quantity):
+        sky.stokes *= units.Jy
 
     smd = pyuvsim.simsetup.SkyModelData(sky)
     assert np.all(sky.stokes.to('Jy').value[0] == smd.stokes_I)
 
     sky2 = smd.get_skymodel()
-    if units.Quantity not in pyradiosky.SkyModel()._stokes.expected_type:
+    if units.Quantity != pyradiosky.SkyModel()._stokes.expected_type:
         sky.stokes = sky.stokes.to("Jy").value
     assert sky2 == sky
 
@@ -1080,6 +1081,14 @@ def test_skymodeldata(component_type, cat_with_some_pols):
 
     assert (smd.ra == sky.ra.deg).all()
     assert (smd.dec == sky.dec.deg).all()
+
+    if isinstance(sky.stokes, units.Quantity):
+        smd.stokes_I *= units.Unit(smd.flux_unit)
+        if smd.polarized is not None:
+            smd.stokes_Q *= units.Unit(smd.flux_unit)
+            smd.stokes_U *= units.Unit(smd.flux_unit)
+            smd.stokes_V *= units.Unit(smd.flux_unit)
+
     assert (smd.stokes_I == sky.stokes[0]).all()
 
     if smd.polarized is not None:

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1090,11 +1090,18 @@ def cat_with_some_pols():
     return sky
 
 
-def test_skymodeldata_with_quantity_stokes(cat_with_some_pols):
+@pytest.mark.parametrize('unit', ['Jy', 'K'])
+def test_skymodeldata_with_quantity_stokes(unit, cat_with_some_pols):
     # Support for upcoming pyradiosky change setting SkyModel.stokes
     # to an astropy Quantity.
-    sky = cat_with_some_pols
-    unit = 'Jy'
+    if unit == 'K':
+        pytest.importorskip('astropy_healpix')
+        path = os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
+        sky = pyradiosky.SkyModel()
+        sky.read_healpix_hdf5(path)
+    else:
+        sky = cat_with_some_pols
+
     if not isinstance(sky.stokes, units.Quantity):
         sky.stokes *= units.Unit(unit)
 
@@ -1117,6 +1124,7 @@ def test_skymodeldata(component_type, cat_with_some_pols):
         path = os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
         sky = pyradiosky.SkyModel()
         sky.read_healpix_hdf5(path)
+
     smd = pyuvsim.simsetup.SkyModelData(sky)
 
     assert (smd.ra == sky.ra.deg).all()

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -177,6 +177,17 @@ def test_gleam_catalog():
     assert gleam_catalog.Ncomponents == 50
 
 
+def test_healpix_catalog():
+    path = os.path.join(SKY_DATA_PATH, 'healpix_disk.hdf5')
+    sky = pyradiosky.SkyModel()
+    sky.read_healpix_hdf5(path)
+
+    params = {'sources': {'catalog': path}}
+    hpx_skymodeldata = pyuvsim.simsetup.initialize_catalog_from_params(params)[0]
+    hpx_sky = hpx_skymodeldata.get_skymodel()
+    assert hpx_sky == sky
+
+
 @pytest.mark.parametrize(
     "spectral_type",
     ["flat", "subband", "spectral_index"])
@@ -237,7 +248,6 @@ def test_vot_catalog_error(key_pop, message):
         pyuvsim.simsetup.initialize_catalog_from_params(param_dict)[0]
 
 
-# parametrize will loop over all the give values
 @pytest.mark.parametrize("config_num", [0, 2])
 def test_param_reader(config_num):
     pytest.importorskip('mpi4py')
@@ -636,7 +646,7 @@ def test_param_select_redundant():
 
 
 @pytest.mark.parametrize('case', np.arange(6))
-def check_uvdata_keyword_init(case):
+def test_uvdata_keyword_init(case):
     base_kwargs = {
         "antenna_layout_filepath": os.path.join(SIM_DATA_PATH,
                                                 "test_config/triangle_bl_layout.csv"),
@@ -1111,7 +1121,7 @@ def test_skymodeldata(component_type, cat_with_some_pols):
         assert sky1_sub._n_polarized == 1
 
 
-@pytest.mark.parametrize('inds', [range(30), range(5), range(9, 14)])
+@pytest.mark.parametrize('inds', [range(30), range(5), np.arange(9, 14)])
 def test_skymodeldata_pol_select(inds, cat_with_some_pols):
     # When running SkyModelData.subselect, confirm that the
     # polarization array and Q, U, V are properly selected.
@@ -1132,7 +1142,7 @@ def test_skymodeldata_pol_select(inds, cat_with_some_pols):
 
 @pytest.mark.parametrize('inds', [range(30), range(5)])
 def test_skymodeldata_attr_bases(inds, cat_with_some_pols):
-    # Check that downselecting doesn't copy length Ncompnent arrays.
+    # Check that downselecting doesn't copy length-Ncomponent arrays.
 
     smd = pyuvsim.simsetup.SkyModelData(cat_with_some_pols)
     smd_copy = smd.subselect(inds)

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1083,23 +1083,6 @@ def cat_with_some_pols():
     return sky
 
 
-@pytest.mark.parametrize('unit', ['Jy', 'K'])
-def test_skymodeldata_with_quantity_stokes(unit, cat_with_some_pols):
-    # Support for upcoming pyradiosky change setting SkyModel.stokes
-    # to an astropy Quantity.
-    sky = cat_with_some_pols
-    if not isinstance(sky.stokes, units.Quantity):
-        sky.stokes *= units.Unit(unit)
-
-    smd = pyuvsim.simsetup.SkyModelData(sky)
-    assert np.all(sky.stokes.to(unit).value[0] == smd.stokes_I)
-
-    sky2 = smd.get_skymodel()
-    if units.Quantity != pyradiosky.SkyModel()._stokes.expected_type:
-        sky.stokes = sky.stokes.to(unit).value
-    assert sky2 == sky
-
-
 @pytest.mark.parametrize('component_type', ['point', 'healpix'])
 def test_skymodeldata(component_type, cat_with_some_pols):
     # Test that SkyModelData class can properly recreate a SkyModel and subselect.

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -114,7 +114,6 @@ def test_catalog_from_params():
     catalog_uv, srclistname = pyuvsim.simsetup.initialize_catalog_from_params(
         {'sources': source_dict}, hera_uv, return_recarray=False
     )
-    catalog_uv = catalog_uv.get_skymodel()
     source_dict['array_location'] = arrloc
     del source_dict['time']
 
@@ -132,8 +131,6 @@ def test_catalog_from_params():
         catalog_str, srclistname2 = pyuvsim.simsetup.initialize_catalog_from_params(
             {'sources': source_dict}, hera_uv, return_recarray=False
         )
-
-    catalog_str = catalog_str.get_skymodel()
     assert np.all(catalog_str == catalog_uv)
 
 
@@ -143,14 +140,14 @@ def test_vot_catalog():
         pyuvsim.simsetup.initialize_catalog_from_params(
             vot_param_filename, return_recarray=False
         )[0]
-    ).get_skymodel()
+    )
 
     txt_param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testcat.yaml')
     txt_catalog = (
         pyuvsim.simsetup.initialize_catalog_from_params(
             txt_param_filename, return_recarray=False
         )[0]
-    ).get_skymodel()
+    )
 
     assert vot_catalog == txt_catalog
 
@@ -164,7 +161,7 @@ def test_gleam_catalog():
             pyuvsim.simsetup.initialize_catalog_from_params(
                 gleam_param_filename, return_recarray=False
             )[0]
-        ).get_skymodel()
+        )
 
     # flux cuts applied
     assert gleam_catalog.Ncomponents == 23
@@ -179,7 +176,7 @@ def test_gleam_catalog():
     with pytest.warns(UserWarning, match="No spectral_type specified for GLEAM, using 'flat'."):
         gleam_catalog = (
             pyuvsim.simsetup.initialize_catalog_from_params(param_dict, return_recarray=False)[0]
-        ).get_skymodel()
+        )
     assert gleam_catalog.Ncomponents == 50
 
 
@@ -190,10 +187,9 @@ def test_healpix_catalog():
     sky.read_healpix_hdf5(path)
 
     params = {'sources': {'catalog': path}}
-    hpx_skymodeldata = pyuvsim.simsetup.initialize_catalog_from_params(
+    hpx_sky = pyuvsim.simsetup.initialize_catalog_from_params(
         params, return_recarray=False
     )[0]
-    hpx_sky = hpx_skymodeldata.get_skymodel()
     assert hpx_sky == sky
 
 
@@ -229,8 +225,7 @@ def test_vot_catalog_warns(key_pop, message):
         pyuvsim.simsetup.initialize_catalog_from_params(
             vot_param_filename, return_recarray=False
         )[0]
-    ).get_skymodel()
-
+    )
     with open(vot_param_filename, 'r') as pfile:
         param_dict = yaml.safe_load(pfile)
     param_dict['config_path'] = os.path.dirname(vot_param_filename)
@@ -239,7 +234,7 @@ def test_vot_catalog_warns(key_pop, message):
     with pytest.warns(UserWarning, match=message):
         vot_catalog2 = (
             pyuvsim.simsetup.initialize_catalog_from_params(param_dict, return_recarray=False)[0]
-        ).get_skymodel()
+        )
 
     assert vot_catalog == vot_catalog2
 

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -923,7 +923,7 @@ def test_fullfreq_check(uvobj_beams_srcs):
         np.arange(Ntasks), uv_obj, sky1, beam_list, beam_dict
     )
 
-    with pytest.raises(ValueError, match="SkyModel spectral type"):
+    with pytest.raises(ValueError, match="Some requested frequencies are not present"):
         next(taskiter0)
 
     next(taskiter1)

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -562,7 +562,7 @@ def test_local_task_gen():
         next(uv_iter0)
     uv_iter1 = pyuvsim.uvdata_to_task_iter(np.arange(Ntasks), hera_uv,
                                            'not_skydata', beam_list, beam_dict)
-    with pytest.raises(TypeError, match='catalog must be a record array'):
+    with pytest.raises(TypeError, match='catalog must be a SkyModelData'):
         next(uv_iter1)
 
     # Copy sources and beams so we don't accidentally reuse quantities.

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -318,7 +318,7 @@ def test_single_offzenith_source_uvfits():
 
     interpolated_beam, interp_basis_vector = beam.interp(
         az_array=np.array([beam_az]), za_array=np.array([beam_za]),
-        freq_array=np.array([freq.to('Hz').value]))
+        freq_array=np.array([freq.to_value('Hz')]))
 
     jones = np.zeros((2, 2, 1), dtype=np.complex64)
     jones[0, 0] = interpolated_beam[1, 0, 0, 0, 0]
@@ -343,7 +343,7 @@ def test_single_offzenith_source_uvfits():
         [vis_analytic[0, 0], vis_analytic[1, 1], vis_analytic[0, 1], vis_analytic[1, 0]]
     )
 
-    assert np.allclose(baseline.uvw.to('m').value, hera_uv.uvw_array[0:hera_uv.Nbls], atol=1e-4)
+    assert np.allclose(baseline.uvw.to_value('m'), hera_uv.uvw_array[0:hera_uv.Nbls], atol=1e-4)
     assert np.allclose(visibility, vis_analytic, atol=1e-4)
 
 
@@ -405,7 +405,7 @@ def test_offzenith_source_multibl_uvfits():
     beam.interpolation_function = 'az_za_simple'
     interpolated_beam, interp_basis_vector = beam.interp(
         az_array=np.array([src_az.rad]), za_array=np.array([src_za.rad]),
-        freq_array=np.array([freq.to('Hz').value])
+        freq_array=np.array([freq.to_value('Hz')])
     )
     jones = np.zeros((2, 2), dtype=np.complex64)
     jones[0, 0] = interpolated_beam[1, 0, 0, 0, 0]
@@ -793,7 +793,7 @@ def test_quantity_reuse(uvobj_beams_srcs):
         locoh_changed = not allclose_or_none(engine.local_coherency, prev_local_coherency)
         srcpos_changed = not allclose_or_none(sky.alt_az, prev_source_pos)
 
-        freq = task.freq.to("Hz").value
+        freq = task.freq.to_value("Hz")
         time = task.time.jd
         beampair = (task.baseline.antenna1.beam_id, task.baseline.antenna2.beam_id)
 

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -625,7 +625,7 @@ def test_task_coverage():
             task_inds, src_inds, Ntasks_local, Nsrcs_local = pyuvsim.uvsim._make_task_inds(
                 Nbls, Ntimes, Nfreqs, Nsrcs, rank, Npus
             )
-            src_inds = range(Nsrcs)[src_inds]   # Turn slice into iterator
+            src_inds = np.arange(Nsrcs)[src_inds]   # Turn slice into iterator
             tasks = itertools.product(task_inds, src_inds)
             tasks_all.append(tasks)
         tasks_all = itertools.chain(*tasks_all)

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -282,11 +282,10 @@ def estimate_skymodel_memory_usage(Ncomponents, Nfreqs):
 
     This aims to anticipate the full memory required to handle a SkyModel
     class in simulation, accounting for its attributes as well as
-    data generated while used.
+    intermediate data generated.
 
     Parameters
     ----------
-
     Ncomponents : int
         Number of source components.
     Nfreqs : int

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -587,7 +587,9 @@ def run_uvsim(params, return_uv=False, quiet=False):
 
     if rank == 0:
         input_uv, beam_list, beam_dict = simsetup.initialize_uvdata_from_params(params)
-        skydata, source_list_name = simsetup.initialize_catalog_from_params(params, input_uv)
+        skydata, source_list_name = simsetup.initialize_catalog_from_params(
+            params, input_uv, return_recarray=False
+        )
 
     input_uv = comm.bcast(input_uv, root=0)
     beam_list = comm.bcast(beam_list, root=0)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -588,7 +588,7 @@ def run_uvsim(params, return_uv=False, quiet=False):
     input_uv = comm.bcast(input_uv, root=0)
     beam_list = comm.bcast(beam_list, root=0)
     beam_dict = comm.bcast(beam_dict, root=0)
-    skydata.share()
+    skydata.share(root=0)
 
     uv_out = run_uvdata_uvsim(
         input_uv, beam_list, beam_dict=beam_dict, catalog=skydata, quiet=quiet

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -590,6 +590,7 @@ def run_uvsim(params, return_uv=False, quiet=False):
         skydata, source_list_name = simsetup.initialize_catalog_from_params(
             params, input_uv, return_recarray=False
         )
+        skydata = simsetup.SkyModelData(skydata)
 
     input_uv = comm.bcast(input_uv, root=0)
     beam_list = comm.bcast(beam_list, root=0)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -270,11 +270,11 @@ def uvdata_to_task_iter(task_ids, input_uv, catalog, beam_list, beam_dict, Nsky_
 
     # The task_ids refer to tasks on the flattened meshgrid.
     if not isinstance(input_uv, UVData):
-        raise TypeError("input_uv must be UVData object")
+        raise TypeError("input_uv must be UVData object.")
 
     #   Skymodel will now be passed in as a catalog array.
     if not isinstance(catalog, SkyModelData):
-        raise TypeError("catalog must be a record array")
+        raise TypeError("catalog must be a SkyModelData object.")
 
     # Splitting the catalog for memory's sake.
     Nsrcs_total = catalog.Ncomponents

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -462,7 +462,8 @@ def run_uvdata_uvsim(input_uv, beam_list, beam_dict=None, catalog=None, quiet=Fa
     Ntasks_tot = Ntimes * Nbls * Nfreqs * Nsky_parts
 
     local_task_iter = uvdata_to_task_iter(
-        task_inds, input_uv, catalog[src_inds], beam_list, beam_dict, Nsky_parts=Nsky_parts
+        task_inds, input_uv, catalog.subselect(src_inds),
+        beam_list, beam_dict, Nsky_parts=Nsky_parts
     )
 
     summed_task_dict = {}

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -320,7 +320,11 @@ def uvdata_to_task_iter(task_ids, input_uv, catalog, beam_list, beam_dict, Nsky_
     time_array = Time(input_uv.time_array, scale='utc', format='jd', location=telescope.location)
     for src_i in src_iter:
         sky = catalog.get_skymodel(src_i)
-        if sky.spectral_type == 'full':
+        if sky.component_type == 'healpix' and hasattr(sky, 'healpix_to_point'):
+            sky.healpix_to_point()
+        if sky.spectral_type != 'flat' and hasattr(sky, 'at_frequencies'):
+            sky.at_frequencies(freq_array[0])
+        elif sky.spectral_type == 'full':
             if not np.allclose(sky.freq_array, freq_array):
                 raise ValueError("SkyModel spectral type is 'full', and "
                                  "its frequencies do not match simulation frequencies.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaces the use of recarrays for sharing SkyModel data with a new object, defined in `pyuvsim.simsetup`, that handles all the required behavior. Also cuts down on memory bloat due to repeating the `freq_array` Ncomponents times when storing as a column in a recarray.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

pyradiosky inherited the "recarray" form of sky models from `pyuvsim`, which was a hacky solution to share sky model data with all MPI processes in a container that is MPI-friendly. It also made sense with how votables and text files were initially read in (as numpy arrays). This partially saved on memory, because much of the data could be put in shared memory windows on each node. As pyradiosky evolved, however, the corresponding recarray definition got more complicated. The addition of the `freq_array` for instance, required that the recarray carry around a column that's just repetitions of the `freq_array`, which is horribly inefficient.

The main impediment to directly using SkyModels in MPI is that several attributes are defined as astropy Quantities (or derived classes, such as Angles, Latitudes, Longitudes), and this information is lost when sharing the data in MPI, unless the slow serialization methods are used (as in `mpi4py.MPI.bcast`). I've added a function to allow broadcasting astropy Quantities to shared memory, but haven't used it much.

This defines a new class, `SkyModelData`, which carries the SkyModel parameters as ndarrays. These arrays can be shared across MPI processes by running the SkyModelData.share() method, which puts arrays in shared memory (if that array has an axis of length `Ncomponents`).

Further, it minimizes Stokes information that is broadcast by only keeping non-stokes I flux values for components which have nonzero polarization. Most simulations won't have many polarized sources, so this can reduce required memory.

closes #293 

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the documentation to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).