### PR TITLE
MPI-enabled tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.2.0] - 2020-7-20
 
 ### Added
+- Support for unit tests parallelized with MPI.
 - Diffuse models in mock catalogs, via the analytic_diffuse module.
 - quantity_shared_bcast function to allow objects derived from astropy.units.Quantity to use shared memory broadcasting.
 - SkyModelData class to replace recarray conversion in pyradiosky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## [1.2.0] - 2020-7-20
+## [Unreleased]
 
 ### Added
 - Support for unit tests parallelized with MPI.
+
+
+## [1.2.0] - 2020-7-20
+
+### Added
 - Diffuse models in mock catalogs, via the analytic_diffuse module.
 - quantity_shared_bcast function to allow objects derived from astropy.units.Quantity to use shared memory broadcasting.
 - SkyModelData class to replace recarray conversion in pyradiosky.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ pytest
 You can alternatively run ```python -m pytest pyuvsim``` or ```python setup.py test```.
 You will need to have all dependencies installed.
 
+Some tests are run in parallel using the mpi4py module. Those tests have a decorator ``pytest.mark.parallel(n)``` where ```n``` is an integer giving the number
+of parallel processes to run the test on. To temporarily disable parallel tests, run pytest with the option ```--nompi```.
+
 ## Where to find Support
 
 Please feel free to submit new issues to the [issue log](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/issues) to request new features, document new bugs, or ask questions.

--- a/pyuvsim/mpi.py
+++ b/pyuvsim/mpi.py
@@ -380,8 +380,7 @@ class Counter:
         nval = _array('i', [0])
         self.win.Get([nval, 1, MPI.INT], 0)
         self.win.Unlock(0)
-        cval = world_comm.allreduce(nval[0], op=MPI.MAX)
-        return cval
+        return nval[0]
 
 
 def get_max_node_rss(return_per_node=False):

--- a/pyuvsim/mpi.py
+++ b/pyuvsim/mpi.py
@@ -360,6 +360,8 @@ class Counter:
             mem = self.win.tomemory()
             mem[:] = _struct.pack('i', 0)
 
+        self.win.Fence()
+
     def free(self):
         self.win.Free()
 

--- a/pyuvsim/tests/conftest.py
+++ b/pyuvsim/tests/conftest.py
@@ -56,7 +56,7 @@ def pytest_addoption(parser):
 def pytest_runtest_setup(item):
     if 'parallel' in item.keywords:
         if mpi is None:
-            pytest.skip("Need mpi4py to run parallelized test.")
+            pytest.skip("Need mpi4py to run parallelized tests.")
         elif item.config.getoption('nompi', False):
             pytest.skip("Skipping parallelized tests with --nompi option.")
 

--- a/pyuvsim/tests/conftest.py
+++ b/pyuvsim/tests/conftest.py
@@ -56,7 +56,7 @@ def pytest_runtest_setup(item):
     if 'parallel' in item.keywords:
         if mpi is None:
             pytest.skip("Need mpi4py to run parallelized test.")
-        elif item.config.getvalue('nompi'):
+        elif item.config.getoption('nompi', False):
             pytest.skip("Skipping parallelized tests with --nompi option.")
 
 

--- a/pyuvsim/tests/conftest.py
+++ b/pyuvsim/tests/conftest.py
@@ -19,6 +19,7 @@ from pyuvdata import UVBeam
 from pyuvdata.data import DATA_PATH
 
 from pyuvsim.astropy_interface import hasmoon, MoonLocation
+from pyuvsim import mpi
 
 
 issubproc = os.environ.get('TEST_IN_PARALLEL', 0)
@@ -45,6 +46,18 @@ def pytest_configure(config):
         "markers",
         "parallel(n): mark test to run in n parallel mpi processes."
     )
+
+
+def pytest_addoption(parser):
+    parser.addoption("--nompi", action="store_true", help="skip mpi-parallelized tests.")
+
+
+def pytest_runtest_setup(item):
+    if 'parallel' in item.keywords:
+        if mpi is None:
+            pytest.skip("Need mpi4py to run parallelized test.")
+        elif item.config.getvalue('nompi'):
+            pytest.skip("Skipping parallelized tests with --nompi option.")
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/pyuvsim/tests/conftest.py
+++ b/pyuvsim/tests/conftest.py
@@ -69,7 +69,6 @@ def pytest_runtest_call(item):
         issubproc = bool(int(issubproc))
     except ValueError:
         pass
-
     call = ['mpirun', '--host', 'localhost:10', '-n', str(nproc),
             "python", "-m", "pytest", "{:s}::{:s}".format(str(item.fspath), str(item.name))]
     call.extend(["--tb=no", '-q', '--runxfail', '-s'])
@@ -79,7 +78,7 @@ def pytest_runtest_call(item):
             envcopy['TEST_IN_PARALLEL'] = '1'
             check_output(call, env=envcopy, timeout=70)
         except (TimeoutExpired, CalledProcessError) as err:
-            message = "Parallelized test {item.name} failed"
+            message = f"Parallelized test {item.name} failed"
             if isinstance(err, TimeoutExpired):
                 message += " due to timeout"
             message += "."

--- a/pyuvsim/tests/test_mpi.py
+++ b/pyuvsim/tests/test_mpi.py
@@ -97,7 +97,7 @@ def test_mem_usage():
     assert np.isclose(change, incsize / 2**30, atol=5e-2)
 
 
-@pytest.mark.parallel(4)
+@pytest.mark.parallel(6)
 def test_mpi_counter():
     mpi.start_mpi()
     count = mpi.Counter()

--- a/pyuvsim/tests/test_mpi.py
+++ b/pyuvsim/tests/test_mpi.py
@@ -23,7 +23,7 @@ import pyradiosky
 
 @pytest.fixture(scope='module', autouse=True)
 def start_mpi():
-    mpi.start_mpi()
+    mpi.start_mpi(False)
 
 
 @pytest.fixture(scope='module')

--- a/pyuvsim/tests/test_mpi.py
+++ b/pyuvsim/tests/test_mpi.py
@@ -50,6 +50,7 @@ def test_mpi_version():
     assert MPI.VERSION == 3
 
 
+@pytest.mark.parallel(2)
 def test_mpi_funcs():
     assert mpi.get_rank() == MPI.COMM_WORLD.rank
     assert mpi.get_Npus() == MPI.COMM_WORLD.size
@@ -96,7 +97,9 @@ def test_mem_usage():
     assert np.isclose(change, incsize / 2**30, atol=5e-2)
 
 
+@pytest.mark.parallel(4)
 def test_mpi_counter():
+    mpi.start_mpi()
     count = mpi.Counter()
     N = 20
     for i in range(N):
@@ -129,6 +132,7 @@ def test_big_gather(MAX_BYTES, fake_tasks):
             assert len(split_info['ranges']) > 1
 
 
+@pytest.mark.parallel(3)
 @pytest.mark.parametrize('MAX_BYTES', [mpi.INT_MAX, 100])
 def test_big_bcast(MAX_BYTES, fake_tasks):
 
@@ -154,6 +158,7 @@ def test_big_bcast(MAX_BYTES, fake_tasks):
             assert len(split_info['ranges']) > 1
 
 
+@pytest.mark.parallel(3)
 def test_big_bcast_gather_loop(fake_tasks):
 
     objs = fake_tasks
@@ -165,6 +170,7 @@ def test_big_bcast_gather_loop(fake_tasks):
         assert broadcast == gathered[0]
 
 
+@pytest.mark.parallel(3)
 def test_sharedmem_bcast_with_quantities():
     # Use mpi.quantity_shared_bcast and check returned objects.
 
@@ -179,6 +185,7 @@ def test_sharedmem_bcast_with_quantities():
         assert np.all(freq_return.to("MHz") == freqs.to("MHz"))
 
 
+@pytest.mark.parallel(3)
 def test_skymodeldata_share():
     # Test the SkyModelData share method.
     sky = pyradiosky.SkyModel(

--- a/pyuvsim/tests/test_mpi.py
+++ b/pyuvsim/tests/test_mpi.py
@@ -105,6 +105,7 @@ def test_mpi_counter():
     N = 20
     for i in range(N):
         count.next()
+    mpi.world_comm.Barrier()
     assert count.current_value() == N * mpi.world_comm.size
     count.free()
 

--- a/pyuvsim/tests/test_mpi.py
+++ b/pyuvsim/tests/test_mpi.py
@@ -97,8 +97,9 @@ def test_mem_usage():
     assert np.isclose(change, incsize / 2**30, atol=5e-2)
 
 
-@pytest.mark.parallel(6)
+@pytest.mark.parallel(4)
 def test_mpi_counter():
+    # Warning -- This test has been flaky in the past.
     mpi.start_mpi()
     count = mpi.Counter()
     N = 20

--- a/pyuvsim/tests/test_run.py
+++ b/pyuvsim/tests/test_run.py
@@ -20,45 +20,45 @@ from pyuvsim.analyticbeam import c_ms
 pytest.importorskip('mpi4py')  # noqa
 
 
-@pytest.mark.filterwarnings("ignore:The frequency field is included in the recarray")
-def test_run_paramfile_uvsim():
+@pytest.fixture
+def goto_tempdir(tmpdir):
+    # Run test within temporary directory.
+    cwd = os.getcwd()
+    os.chdir(str(tmpdir))
+
+    yield
+
+    os.chdir(cwd)
+
+@pytest.mark.parametrize('paramfile', ['param_1time_1src_testcat.yaml',
+                                       'param_1time_1src_testvot.yaml'])
+@pytest.mark.parallel(2)
+def test_run_paramfile_uvsim(goto_tempdir, paramfile):
     # Test vot and txt catalogs for parameter simulation
     # Compare to reference files.
-
     uv_ref = UVData()
     uv_ref.read_uvfits(os.path.join(SIM_DATA_PATH, 'testfile_singlesource.uvfits'))
     uv_ref.unphase_to_drift(use_ant_pos=True)
 
-    param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testcat.yaml')
-    with open(param_filename) as pfile:
-        params_dict = yaml.safe_load(pfile)
-    tempfilename = params_dict['filing']['outfile_name']
-
+    param_filename = os.path.join(SIM_DATA_PATH, 'test_config', paramfile)
     # This test obsparam file has "single_source.txt" as its catalog.
     pyuvsim.uvsim.run_uvsim(param_filename)
 
-    uv_new_txt = UVData()
+    # For rank != 0, the tempdir will be different.
+    # This gets the path to the output file to all processes.
+    path = pyuvsim.mpi.world_comm.bcast(os.getcwd(), root=0)
+    ofilepath = os.path.join(path, 'tempfile.uvfits')
+
+    uv_new = UVData()
     with pytest.warns(UserWarning, match='antenna_diameters is not set'):
-        uv_new_txt.read_uvfits(tempfilename)
+        uv_new.read_uvfits(ofilepath)
 
-    uv_new_txt.unphase_to_drift(use_ant_pos=True)
-    os.remove(tempfilename)
+    uv_new.unphase_to_drift(use_ant_pos=True)
 
-    param_filename = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testvot.yaml')
-    pyuvsim.uvsim.run_uvsim(param_filename)
-
-    uv_new_vot = UVData()
-    with pytest.warns(UserWarning, match='antenna_diameters is not set'):
-        uv_new_vot.read_uvfits(tempfilename)
-
-    uv_new_vot.unphase_to_drift(use_ant_pos=True)
-    os.remove(tempfilename)
-    uv_new_txt.history = uv_ref.history  # History includes irrelevant info for comparison
-    uv_new_vot.history = uv_ref.history
-    uv_new_txt.object_name = uv_ref.object_name
-    uv_new_vot.object_name = uv_ref.object_name
-    assert uv_new_txt == uv_ref
-    assert uv_new_vot == uv_ref
+    # Reset parts that will deviate
+    uv_new.history = uv_ref.history
+    uv_new.object_name = uv_ref.object_name
+    assert uv_new == uv_ref
 
 
 @pytest.mark.parametrize('model', ['monopole', 'cosza', 'quaddome', 'monopole-nonflat'])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Defines a new pytest marker that tells pytest to run a given test as a subprocess. Within the subprocess, the given test is run using `mpirun` and a user-specified number of MPI processes (up to 10). This marker is applied to several of the tests in `test_mpi.py`. Using this, I found that adding a win.Fence() to the counter made the counter test pass consistently, so it will no longer be skipped.

A command line option `--nompi` will disable the parallelized tests.

I'm not sure how to test it automatically, but I've included some hooks that will print the stack traces separately for each mpi process, labelled by COMM_WORLD rank, when a test fails. This can be seen by temporarily breaking a parallelized test. There is also a settable "timeout" option to handle cases where MPI causes a deadlock.

(This was branched off of reorganize_tests, and so should be merged there or merged into master after PR #309 is merged)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It has been a long-standing issue to parallelize our tests, since many bugs have only come up when running pyuvsim on multiple MPI ranks.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

Closes #235 
Closes #126 

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the documentation to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).