### PR TITLE
Fix filename in the 2nd reference sim readme

### DIFF
--- a/reference_simulations/second_generation/README.md
+++ b/reference_simulations/second_generation/README.md
@@ -21,7 +21,7 @@ We detail the set of reference simulations below.
 |   obsparam_ref_2.1_airy.yaml      |               gleam.vot              |   60   |   128  | MWA_nocore |   airy      | ref_2.1_airy.uvh5         |
 |  obsparam_ref_2.2_uvbeam.yaml     |               gleam.vot              |   1    |   128  | MWA_nocore | HERA_UVBeam | ref_2.2_uvbeam_gleam.uvh5 |
 | obsparam_ref_2.3_airy_flatPS.yaml | healpix_flat_EoR_spectrum_noise.hdf5 |   1    |   128  | MWA_nocore |   airy      | ref_2.3_airy_flatPS.uvh5  |
-|  obsparam_ref_1.3_gauss.yaml      |       healpix_gsm_shell.hdf5         |   1    |   128  | MWA_nocore |   airy      | ref_2.3_airy_gsm.uvh5     |
+|  obsparam_ref_2.3_airy_gsm.yaml   |       healpix_gsm_shell.hdf5         |   1    |   128  | MWA_nocore |   airy      | ref_2.3_airy_gsm.uvh5     |
 
 
 The total number of data points is constrained by the current level of optimization and availability of computing resources. pyuvsim is currently running on the Oscar cluster at Brown University, given limitations of memory and processor availability.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The param file in the readme for the second reference sim was wrong.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [x] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)
