### PR TITLE
remove sleep from pbar update loop

### DIFF
--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -4,7 +4,6 @@
 
 import numpy as np
 import yaml
-import time
 from astropy.coordinates import EarthLocation
 import astropy.units as units
 from astropy.units import Quantity
@@ -491,7 +490,6 @@ def run_uvdata_uvsim(input_uv, beam_list, beam_dict=None, catalog=None, quiet=Fa
         if rank == 0 and not quiet:
             cval = count.current_value()
             pbar.update(cval)
-        time.sleep(1)
 
     count.free()
     if rank == 0 and not quiet:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
remove sleep introduced in last PR. Turns out it serializes the execution of the task loop, 
Ran reference sim 1.1 before and after this change and the before is very slow, but after completes in ~.03 minutes same as before last PR

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.