### PR TITLE
Propagate Clobber to skyh5 and uvh5

### DIFF
--- a/ci/herasim.yaml
+++ b/ci/herasim.yaml
@@ -24,7 +24,7 @@ dependencies:
   - setuptools_scm
   - pip:
     - cached-property
-    - pyradiosky>=0.1.0
+    - pyradiosky>=0.1.2
     - vis-cpu>=0.2.0
     - git+https://github.com/HERA-Team/uvtools.git
     - git+https://github.com/rasg-affiliates/healvis

--- a/ci/min_deps.yaml
+++ b/ci/min_deps.yaml
@@ -15,4 +15,4 @@ dependencies:
   - scipy
   - setuptools_scm
   - pip:
-    - pyradiosky>=0.1.0
+    - pyradiosky>=0.1.2

--- a/ci/publish.yaml
+++ b/ci/publish.yaml
@@ -12,5 +12,5 @@ dependencies:
   - scipy
   - setuptools_scm
   - pip:
-    - pyradiosky>=0.1.0
+    - pyradiosky>=0.1.2
     - pep517

--- a/ci/rtd_env.yml
+++ b/ci/rtd_env.yml
@@ -12,4 +12,4 @@ dependencies:
   - conda-forge::pyuvdata>=2.1.3
   - conda-forge::pypandoc
   - pip:
-    - pyradiosky>=0.1.0
+    - pyradiosky>=0.1.2

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -19,6 +19,6 @@ dependencies:
   - scipy
   - setuptools_scm
   - pip:
-    - pyradiosky>=0.1.0
+    - pyradiosky>=0.1.2
     - lunarsky
     - git+git://github.com/aelanman/analytic_diffuse

--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,6 @@ dependencies:
   - setuptools_scm
   - sphinx
   - pip:
-    - pyradiosky>=0.1.0
+    - pyradiosky>=0.1.2
     - lunarsky
     - git+git://github.com/aelanman/analytic_diffuse

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -235,7 +235,7 @@ def test_skyh5_catalog(tmp_path):
     assert skyobj.Ncomponents == 50
 
     skyh5_file = os.path.join(tmp_path, 'gleam.skyh5')
-    skyobj.write_skyh5(skyh5_file)
+    skyobj.write_skyh5(skyh5_file, clobber=True)
 
     starting_param_filename = os.path.join(
         SIM_DATA_PATH, 'test_config', 'param_1time_1src_testcat.yaml'
@@ -261,7 +261,7 @@ def test_skyh5_catalog(tmp_path):
 
     # test works with `hdf5` extension:
     hdf5_file = os.path.join(tmp_path, 'gleam.hdf5')
-    skyobj.write_skyh5(hdf5_file)
+    skyobj.write_skyh5(hdf5_file, clobber=True)
 
     param_dict['sources']['catalog'] = hdf5_file
     with open(param_filename, 'w') as yfile:
@@ -276,7 +276,7 @@ def test_skyh5_catalog(tmp_path):
 
     # test error with unknown extension
     h5_file = os.path.join(tmp_path, 'gleam.h5')
-    skyobj.write_skyh5(h5_file)
+    skyobj.write_skyh5(hdf5_file, clobber=True)
 
     param_dict['sources']['catalog'] = h5_file
     with open(param_filename, 'w') as yfile:

--- a/pyuvsim/tests/test_utils.py
+++ b/pyuvsim/tests/test_utils.py
@@ -129,6 +129,46 @@ def test_write_uvdata(save_format, tmpdir):
 
 
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not self-consistent")
+@pytest.mark.parametrize("save_format", [None, 'uvfits', 'miriad', 'uvh5'])
+def test_write_uvdata_clobber(save_format, tmpdir):
+    """ Test function that defines filenames from parameter dict """
+    uv = UVData()
+    uv.read_uvfits(triangle_uvfits_file)
+    uv.set_lsts_from_time_array()
+    ofname = str(tmpdir.join('test_file'))
+    filing_dict = {'outfile_name': ofname}
+    expected_ofname = simutils.write_uvdata(
+        uv,
+        filing_dict,
+        return_filename=True,
+        out_format=save_format,
+    )
+
+    ofname = os.path.join('.', ofname)
+
+    assert os.path.exists(expected_ofname)
+
+    uv2 = UVData()
+    uv2.read(expected_ofname)
+
+    assert uv == uv2
+
+    uv.data_array += 1
+
+    filing_dict["clobber"] = True
+    simutils.write_uvdata(
+        uv,
+        filing_dict,
+        out_format=save_format,
+    )
+
+    assert uv2 != uv
+
+    uv2.read(expected_ofname)
+    assert uv2 == uv
+
+
+@pytest.mark.filterwarnings("ignore:LST values stored in this file are not self-consistent")
 def test_write_error_with_no_format(tmpdir):
     """Test write_uvdata will error if no format is given."""
     uv = UVData()

--- a/pyuvsim/tests/test_utils.py
+++ b/pyuvsim/tests/test_utils.py
@@ -151,6 +151,9 @@ def test_write_uvdata_clobber(save_format, tmpdir):
     uv2 = UVData()
     uv2.read(expected_ofname)
 
+    # munge the filename attribute
+    uv2.filename = uv.filename
+
     assert uv == uv2
 
     uv.data_array += 1
@@ -161,10 +164,14 @@ def test_write_uvdata_clobber(save_format, tmpdir):
         filing_dict,
         out_format=save_format,
     )
-
+    # munge the filename attribute to make sure inequailty is from the data
+    uv2.filename = uv.filename
     assert uv2 != uv
 
     uv2.read(expected_ofname)
+
+    # munge the filename attribute
+    uv2.filename = uv.filename
     assert uv2 == uv
 
 

--- a/pyuvsim/tests/test_utils.py
+++ b/pyuvsim/tests/test_utils.py
@@ -151,8 +151,11 @@ def test_write_uvdata_clobber(save_format, tmpdir):
     uv2 = UVData()
     uv2.read(expected_ofname)
 
+    # Depending on pyuvdat version the filename may exist
     # munge the filename attribute
-    uv2.filename = uv.filename
+    # This can be removed if we ever require pyuvdata>=2.21
+    if hasattr(uv2, "filename"):
+        uv2.filename = uv.filename
 
     assert uv == uv2
 
@@ -164,14 +167,16 @@ def test_write_uvdata_clobber(save_format, tmpdir):
         filing_dict,
         out_format=save_format,
     )
-    # munge the filename attribute to make sure inequailty is from the data
-    uv2.filename = uv.filename
+
+    if hasattr(uv2, "filename"):
+        uv2.filename = uv.filename
+
     assert uv2 != uv
 
     uv2.read(expected_ofname)
 
-    # munge the filename attribute
-    uv2.filename = uv.filename
+    if hasattr(uv2, "filename"):
+        uv2.filename = uv.filename
     assert uv2 == uv
 
 

--- a/pyuvsim/tests/test_utils.py
+++ b/pyuvsim/tests/test_utils.py
@@ -131,7 +131,7 @@ def test_write_uvdata(save_format, tmpdir):
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not self-consistent")
 @pytest.mark.parametrize("save_format", [None, 'uvfits', 'miriad', 'uvh5'])
 def test_write_uvdata_clobber(save_format, tmpdir):
-    """ Test function that defines filenames from parameter dict """
+    """Test overwriting a uvdata object yields the expected results."""
     uv = UVData()
     uv.read_uvfits(triangle_uvfits_file)
     uv.set_lsts_from_time_array()

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -181,7 +181,6 @@ def write_uvdata(
     return_filename=False,
     dryrun=False,
     out_format=None,
-    clobber=True,
 ):
     """
     Parse output file information from parameters and write uvfits to file.

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -175,19 +175,32 @@ def check_file_exists_and_increment(filepath, extension=None):
     return filepath
 
 
-def write_uvdata(uv_obj, param_dict, return_filename=False, dryrun=False, out_format=None):
+def write_uvdata(
+    uv_obj,
+    param_dict,
+    return_filename=False,
+    dryrun=False,
+    out_format=None,
+    clobber=True,
+):
     """
     Parse output file information from parameters and write uvfits to file.
 
-    Args:
-        uv_obj: UVData object to write out.
-        param_dict: parameter dictionary defining output path, filename, and
-                    whether or not to clobber.
-        return_filename: (Default false) Return the file path
-        dryrun: (Default false) Don't write to file.
-        out_format: (Default uvfits) Write as uvfits/miriad/uvh5
+    Parameters
+    ----------
+    uv_obj : UVData Object
+        The object to be written out.
+    param_dict : Dict
+        parameter dictionary defining output path, filename, and whether or not to clobber.
+    return_filename : Bool
+        (Default false) Return the file path
+    dryrun : Bool
+        (Default false) Don't write to file.
+    out_format : Str
+        (Default uvfits) Write as uvfits/miriad/uvh5
 
-    Returns:
+    Returns
+    -------
         File path, if return_filename is True
     """
     if 'filing' in param_dict.keys():
@@ -233,7 +246,7 @@ def write_uvdata(uv_obj, param_dict, return_filename=False, dryrun=False, out_fo
         elif out_format == 'miriad':
             uv_obj.write_miriad(outfile_name, clobber=not noclobber)
         elif out_format == 'uvh5':
-            uv_obj.write_uvh5(outfile_name)
+            uv_obj.write_uvh5(outfile_name, clobber=not noclobber)
         else:
             raise ValueError(
                 "Invalid output format. Options are \" uvfits\", \"uvh5\", or \"miriad\"")

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup_args = {
     'use_scm_version': {'local_scheme': branch_scheme},
     'include_package_data': True,
     'install_requires': ['numpy>=1.15', 'scipy', 'astropy>=4.0', 'pyyaml',
-                         'pyradiosky>=0.1.0', 'pyuvdata>=2.1.3', 'setuptools_scm'],
+                         'pyradiosky>=0.1.2', 'pyuvdata>=2.1.3', 'setuptools_scm'],
     'test_requires': ['pytest'],
     'classifiers': ['Development Status :: 5 - Production/Stable',
                     'Intended Audience :: Science/Research',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixes #340 
propagates the clobber keyword from pyradiosky into some tests that call `write_skyh5` requires RadioAstronomySoftwareGroup/pyradiosky#144