### PR TITLE
fix: SkyModelData.name must be an array not a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Fix bugs in reading catalogs using pyradiosky for `skyh5` files and files with unusual extension names.
 - Corrects the distribution of random points for the random mock catalog.
 - pixel interpolation was defaulting to az_za_simple for all beams, breaking healpix-coord UVBeams.
-
+- `SkyModel.name` is now coerced to an array.
 ## [1.2.0] - 2020-7-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@
 - Use remote memory access to collect finished visibility data, without serialization.
 
 ### Fixed
+- `SkyModel.name` is now coerced to an array.
 - Bug MPI-enabled tests which caused failure on tests that wouldn't pass in serial mode.
 - Fix bugs in reading catalogs using pyradiosky for `skyh5` files and files with unusual extension names.
 - Corrects the distribution of random points for the random mock catalog.
 - pixel interpolation was defaulting to az_za_simple for all beams, breaking healpix-coord UVBeams.
-- `SkyModel.name` is now coerced to an array.
+
 ## [1.2.0] - 2020-7-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ Required:
 * pyuvdata>=2.1.3
 * pyradiosky>=0.1.0
 * setuptools_scm
+* psutil
 
 Optional:
 
 * mpi4py>=3.0.0
-* psutil
 * line_profiler
 * lunarsky
 

--- a/ci/min_deps.yaml
+++ b/ci/min_deps.yaml
@@ -14,5 +14,6 @@ dependencies:
   - pyyaml>=5.1
   - scipy
   - setuptools_scm
+  - psutil
   - pip:
     - pyradiosky>=0.1.2

--- a/ci/publish.yaml
+++ b/ci/publish.yaml
@@ -11,6 +11,7 @@ dependencies:
   - pyyaml>=5.1
   - scipy
   - setuptools_scm
+  - psutil
   - pip:
     - pyradiosky>=0.1.2
     - pep517

--- a/ci/rtd_env.yml
+++ b/ci/rtd_env.yml
@@ -11,5 +11,6 @@ dependencies:
   - setuptools_scm
   - conda-forge::pyuvdata>=2.1.3
   - conda-forge::pypandoc
+  - psutil
   - pip:
     - pyradiosky>=0.1.2

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -418,7 +418,10 @@ class SkyModelData:
     def __init__(self, sky_in=None):
         # Collect relevant attributes.
         if sky_in is not None:
-            self.name = np.asarray(sky_in.name) if sky_in.name is not None else None
+            if sky_in.name is not None:
+                self.name = np.asarray(sky_in.name)
+            else:
+                self.name = None
             self.nside = sky_in.nside
             self.hpx_inds = sky_in.hpx_inds
             self.component_type = sky_in.component_type

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -418,7 +418,7 @@ class SkyModelData:
     def __init__(self, sky_in=None):
         # Collect relevant attributes.
         if sky_in is not None:
-            self.name = np.asarray(sky_in.name)
+            self.name = np.asarray(sky_in.name) if sky_in.name is not None else None
             self.nside = sky_in.nside
             self.hpx_inds = sky_in.hpx_inds
             self.component_type = sky_in.component_type

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -418,7 +418,7 @@ class SkyModelData:
     def __init__(self, sky_in=None):
         # Collect relevant attributes.
         if sky_in is not None:
-            self.name = sky_in.name
+            self.name = np.asarray(sky_in.name)
             self.nside = sky_in.nside
             self.hpx_inds = sky_in.hpx_inds
             self.component_type = sky_in.component_type

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -8,7 +8,7 @@ import time as pytime
 from datetime import timedelta
 
 import numpy as np
-    import psutil
+import psutil
 
 from . import __version__
 
@@ -258,12 +258,6 @@ def get_avail_memory():
     If this is not called from within a SLURM task, it will estimate
     using psutils methods.
     """
-    if not HAVE_PSUTIL:
-        raise ImportError("You need psutils to estimate available memory. "
-                          "Install it by running pip install pyuvsim[sim] "
-                          "or pip install pyuvsim[all] if you also want "
-                          "the line_profiler installed.")
-
     slurm_key = 'SLURM_MEM_PER_NODE'
     if slurm_key in os.environ:
         return float(os.environ[slurm_key]) * 1e6  # MB -> B

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -11,7 +11,7 @@ import numpy as np
 try:
     import psutil
     HAVE_PSUTIL = True
-except ImportError:
+except ImportError:  # pragma: no cover
     HAVE_PSUTIL = False
 
 from . import __version__

--- a/pyuvsim/utils.py
+++ b/pyuvsim/utils.py
@@ -8,11 +8,7 @@ import time as pytime
 from datetime import timedelta
 
 import numpy as np
-try:
     import psutil
-    HAVE_PSUTIL = True
-except ImportError:  # pragma: no cover
-    HAVE_PSUTIL = False
 
 from . import __version__
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup_args = {
     'use_scm_version': {'local_scheme': branch_scheme},
     'include_package_data': True,
     'install_requires': ['numpy>=1.15', 'scipy', 'astropy>=4.0', 'pyyaml',
-                         'pyradiosky>=0.1.2', 'pyuvdata>=2.1.3', 'setuptools_scm'],
+                         'pyradiosky>=0.1.2', 'pyuvdata>=2.1.3', 'setuptools_scm', 'psutil'],
     'test_requires': ['pytest'],
     'classifiers': ['Development Status :: 5 - Production/Stable',
                     'Intended Audience :: Science/Research',
@@ -38,10 +38,10 @@ setup_args = {
                     'Topic :: Scientific/Engineering :: Astronomy'],
     'keywords': 'radio astronomy interferometry',
     'extras_require': {
-        'sim': ['mpi4py>=3.0.0', 'psutil'],
-        'all': ['mpi4py>=3.0.0', 'psutil', 'line_profiler', 'lunarsky'],
-        'moon': ['mpi4py>=3.0.0', 'psutil', 'lunarsky'],
-        'dev': ['mpi4py>=3.0.0', 'psutil', 'line_profiler', 'pypandoc',
+        'sim': ['mpi4py>=3.0.0'],
+        'all': ['mpi4py>=3.0.0', 'line_profiler', 'lunarsky'],
+        'moon': ['mpi4py>=3.0.0', 'lunarsky'],
+        'dev': ['mpi4py>=3.0.0', 'line_profiler', 'pypandoc',
                 'pytest', 'pytest-cov', 'sphinx', 'pre-commit', 'lunarsky']
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This does two things:

1. Adds `psutil` as a dependency (rather than optional extra). `psutil` is used in a default run, so it should not be optional.
2. Makes sure the `SkyModel.name` attribute is an array, not a list. By default, the `SkyModel` object creates a list for a healpix map. But then doing `subselect` breaks because an index range can't be used on lists.

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).

