### PR TITLE
feat: ability to do consistency checks on beam lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## [1.2.1] - 2021-10-13
 
 ### Added
+- New `check_consistency` method for `BeamList` objects.
 - Support for writing out measurement set files.
 - Support for unit tests parallelized with MPI.
 - Require that future changes not drastically increase runtime for current capabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- New `check_consistency` method for `BeamList` objects.
 - Ability to simulate UVData objects where Nblts != Nbls * Ntimes. Currently only supported with direct `run_uvdata_uvsim` calls.
 
 ### Fixed
@@ -11,7 +12,6 @@
 ## [1.2.1] - 2021-10-13
 
 ### Added
-- New `check_consistency` method for `BeamList` objects.
 - Support for writing out measurement set files.
 - Support for unit tests parallelized with MPI.
 - Require that future changes not drastically increase runtime for current capabilities.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,7 +164,7 @@ texinfo_documents = [
 napoleon_use_rtype = False
 napoleon_use_param = False
 napoleon_custom_sections = [("Attributes", "params_style")]
-
+autodoc_typehints = 'both'
 
 def build_custom_docs(app):
     sys.path.append(os.getcwd())

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,7 +164,7 @@ texinfo_documents = [
 napoleon_use_rtype = False
 napoleon_use_param = False
 napoleon_custom_sections = [("Attributes", "params_style")]
-autodoc_typehints = 'both'
+autodoc_typehints = 'signature'
 
 def build_custom_docs(app):
     sys.path.append(os.getcwd())

--- a/pyuvsim/telescope.py
+++ b/pyuvsim/telescope.py
@@ -11,6 +11,12 @@ from .analyticbeam import AnalyticBeam
 from . import mpi
 
 
+class BeamConsistencyError(Exception):
+    """An Exception class to mark inconsistencies among beams in a BeamList."""
+
+    pass
+
+
 class BeamList:
     """
     A container for the set of beam models and related parameters.
@@ -44,19 +50,17 @@ class BeamList:
         Passing in a mixture of strings and objects will error.
     uvb_params : dict (optional)
         Options to set uvb_params, overriding settings from passed-in UVBeam objects.
-
-    check
+    check : bool
         Whether to perform a consistency check on the beams (i.e. asserting that several
         of their defining parameters are the same for all beams in the list).
-
-    force_check
+    force_check : bool
         The consistency check is only possible for object-beams (not string mode). If
         `force_check` is True, it will convert beams to object-mode to force the check
         to run (then convert back to string mode).
 
     Raises
     ------
-    ValueError :
+    ValueError
         For an invalid beam_list (mix of strings and objects).
 
     Notes
@@ -406,8 +410,7 @@ class BeamList:
 
     @classmethod
     def _obj_to_str(cls, beam_model):
-        # Convert beam objects to strings that may generate them.
-
+        """Convert beam objects to strings that may generate them."""
         if isinstance(beam_model, str):
             return beam_model
         if isinstance(beam_model, AnalyticBeam):
@@ -486,12 +489,6 @@ class BeamList:
 
         if check:
             self.check_consistency()
-
-
-class BeamConsistencyError(Exception):
-    """An Exception class to mark inconsistencies among beams in a BeamList."""
-
-    pass
 
 
 class Telescope:

--- a/pyuvsim/telescope.py
+++ b/pyuvsim/telescope.py
@@ -110,7 +110,8 @@ class BeamList:
             self.check_consistency(force=force_check)
 
     def check_consistency(self, force: bool = False):
-        """Check the consistency of all beams in the list.
+        """
+        Check the consistency of all beams in the list.
 
         This checks basic parameters of the objects for consistency, eg. the ``beam_type``.
         It is meant to be manually called by the user.
@@ -126,6 +127,7 @@ class BeamList:
         ------
         BeamConsistencyError
             If any beam is inconsistent with the rest of the beams.
+
         """
         if self.string_mode:
             if not force:
@@ -173,12 +175,14 @@ class BeamList:
 
     @property
     def x_orientation(self):
-        """The x_orientation of all beams in list (if consistent).
+        """
+        Return the x_orientation of all beams in list (if consistent).
 
         Raises
         ------
         BeamConsistencyError
             If the beams in the list are not consistent with each other.
+
         """
         if not self.is_consistent:
             self.check_consistency(force=True)
@@ -215,12 +219,14 @@ class BeamList:
 
     @property
     def beam_type(self):
-        """The beam_type of all beams in list (if consistent).
+        """
+        Return the beam_type of all beams in list (if consistent).
 
         Raises
         ------
         BeamConsistencyError
             If the beams in the list are not consistent with each other.
+
         """
         if not self.is_consistent:
             self.check_consistency(force=True)
@@ -304,6 +310,7 @@ class BeamList:
 
         Converts objects to strings if in object mode,
         or vice versa if in string mode.
+
         """
         if self.string_mode:
             # If value is a string, then _scrape_uvb_params returns an empty dictionary.
@@ -346,6 +353,7 @@ class BeamList:
 
         Converts objects to strings if in object mode,
         or vice versa if in string mode.
+
         """
         if self.string_mode:
             self._str_beam_list.append('')
@@ -442,6 +450,7 @@ class BeamList:
         ValueError:
             If any UVBeam objects lack a "beam_path" keyword in the "extra_keywords"
             attribute, specifying the path to the beamfits file that generates it.
+
         """
         if self._obj_beam_list != []:
             # Convert object beams to string definitions
@@ -481,6 +490,8 @@ class BeamList:
 
 
 class BeamConsistencyError(Exception):
+    """An Exception class to mark inconsistencies among beams in a BeamList."""
+
     pass
 
 

--- a/pyuvsim/telescope.py
+++ b/pyuvsim/telescope.py
@@ -13,6 +13,7 @@ from . import mpi
 
 
 def consistent(method):
+    """Decorator for checking consistency before accessing a parameter."""
     @functools.wraps(method)
     def inner(self):
         if not self.is_consistent:
@@ -55,6 +56,15 @@ class BeamList:
     uvb_params : dict (optional)
         Options to set uvb_params, overriding settings from passed-in UVBeam objects.
 
+    check
+        Whether to perform a consistency check on the beams (i.e. asserting that several
+        of their defining parameters are the same for all beams in the list).
+
+    force_check
+        The consistency check is only possible for object-beams (not string mode). If
+        `force_check` is True, it will convert beams to object-mode to force the check
+        to run (then convert back to string mode).
+
     Raises
     ------
     ValueError :
@@ -74,7 +84,13 @@ class BeamList:
 
     string_mode = True
 
-    def __init__(self, beam_list=None, uvb_params=None, check: bool = True, force_check: bool=False):
+    def __init__(
+        self,
+        beam_list=None,
+        uvb_params=None,
+        check: bool = True,
+        force_check: bool = False
+    ):
 
         self.uvb_params = {'freq_interp_kind': 'cubic',
                            'interpolation_function': 'az_za_simple'}
@@ -127,20 +143,18 @@ class BeamList:
     def feed_array(self):
         """The feed_array of all beams in list (if consistent)."""
         return getattr(self._obj_beam_list[0], "feed_array", None)
-    
+
     @consistent
     @property
     def polarization_array(self):
         """The polarization_array of all beams in list (if consistent)."""
         return getattr(self._obj_beam_list[0], "polarization_array", None)
-    
 
     @consistent
     @property
     def Nfeeds(self):
         """The Nfeeds of all beams in list (if consistent)."""
         return getattr(self._obj_beam_list[0], "Nfeeds", None)
-    
 
     def _scrape_uvb_params(self, beam_objs, strict=True):
         """
@@ -363,7 +377,7 @@ class BeamList:
         self._obj_beam_list = []
         self.string_mode = True
 
-    def set_obj_mode(self, use_shared_mem=False, check: bool=True):
+    def set_obj_mode(self, use_shared_mem=False, check: bool = True):
         """
         Initialize AnalyticBeam and UVBeam objects from string representations.
 
@@ -378,11 +392,11 @@ class BeamList:
         self._set_params_on_uvbeams(self._obj_beam_list)
         self._str_beam_list = []
         self.string_mode = False
-        
+
         if check:
             self.check_consistency()
 
-    def check_consistency(self, check_pols: bool = True, force: bool=False):
+    def check_consistency(self, check_pols: bool = True, force: bool = False):
         """Check the consistency of all beams in the list.
 
         This checks basic parameters of the objects for consistency, eg. the ``beam_type``.
@@ -443,6 +457,7 @@ class BeamList:
                 check_thing("x_orientation", j)
 
         self.is_consistent = True
+
 
 class BeamConsistencyError(Exception):
     pass

--- a/pyuvsim/telescope.py
+++ b/pyuvsim/telescope.py
@@ -198,7 +198,11 @@ class BeamList:
                 xorient = b.x_orientation
                 break
         else:
-            raise AttributeError("x_orientation not defined for this beam list.")
+            # None of the constituent beams has defined x_orientation.
+            # Here we return None, instead of raising an attribute error, to maintain
+            # backwards compatibility (pyuvsim access the beamlist.x_orientation without
+            # checking for its existence).
+            return None
 
         if xorient is None:
             warnings.warn(

--- a/pyuvsim/telescope.py
+++ b/pyuvsim/telescope.py
@@ -408,8 +408,7 @@ class BeamList:
         uvb.extra_keywords['beam_path'] = path
         return uvb
 
-    @classmethod
-    def _obj_to_str(cls, beam_model):
+    def _obj_to_str(self, beam_model):
         """Convert beam objects to strings that may generate them."""
         if isinstance(beam_model, str):
             return beam_model
@@ -417,7 +416,7 @@ class BeamList:
             btype = beam_model.type
 
             bm_str = 'analytic_' + btype
-            for abbrv, full in cls._float_params.items():
+            for abbrv, full in self._float_params.items():
                 val = getattr(beam_model, full)
                 if val is not None:
                     bm_str += '_' + abbrv + '=' + str(val)

--- a/pyuvsim/telescope.py
+++ b/pyuvsim/telescope.py
@@ -352,6 +352,14 @@ class BeamList:
     def check_consistency(self, check_pols: bool = True):
         """Check the consistency of all beams in the list.
 
+        This checks basic parameters of the objects for consistency, eg. the ``beam_type``.
+        It is meant to be manually called by the user.
+
+        Parameters
+        ----------
+        check_pols
+            Whether to check polarization-related parameters.
+
         Raises
         ------
         BeamConsistencyError

--- a/pyuvsim/telescope.py
+++ b/pyuvsim/telescope.py
@@ -130,7 +130,8 @@ class BeamList:
         if self.string_mode:
             if not force:
                 warnings.warn(
-                    "Cannot check consistency of a string-mode BeamList!"
+                    "Cannot check consistency of a string-mode BeamList! Set force=True"
+                    " to force consistency checking."
                 )
                 return
             else:

--- a/pyuvsim/telescope.py
+++ b/pyuvsim/telescope.py
@@ -118,7 +118,7 @@ class BeamList:
 
         Parameters
         ----------
-        force
+        force : bool
             Whether to force the consistency check even if the object is in string
             mode. This wil convert to to object mode, perform the check, then
             convert back.
@@ -245,7 +245,6 @@ class BeamList:
         beam_objs : list
             If any UVBeams are found in this list, they will be scraped
             for relevant parameters.
-
         strict : bool
             If True, will raise an error if the UVBeams in beam_objs
             have conflicting parameters.
@@ -471,9 +470,9 @@ class BeamList:
 
         Parameters
         ----------
-        use_shared_mem
+        use_shared_mem : bool
             Whether to use shared memory for the beam data.
-        check
+        check : bool
             Whether to perform consistency checks on all the beams in the list after
             conversion to object mode.
 

--- a/pyuvsim/tests/test_telescope.py
+++ b/pyuvsim/tests/test_telescope.py
@@ -200,7 +200,7 @@ def test_beamlist_errors(beam_objs):
         match="All polarized beams have x_orientation set to None. This will make it "
         "hard to interpret the polarizations of the simulated visibilities.",
     ):
-        pyuvsim.BeamList(newbeams)
+        pyuvsim.BeamList(newbeams).x_orientation
 
     # Compare Telescopes with beamlists of different lengths
     del newbeams[0]

--- a/pyuvsim/tests/test_telescope.py
+++ b/pyuvsim/tests/test_telescope.py
@@ -189,7 +189,10 @@ def test_beamlist_errors(beam_objs):
 
     # test error on beams with different x_orientation
     newbeams[0].x_orientation = None
-    with pytest.raises(BeamConsistencyError):
+    with pytest.raises(
+        BeamConsistencyError,
+        match='x_orientation of beam 1 is not consistent with beam 2'
+    ):
         pyuvsim.BeamList(newbeams, check=True)
 
     # test warning on beams with different x_orientation

--- a/pyuvsim/tests/test_telescope.py
+++ b/pyuvsim/tests/test_telescope.py
@@ -215,11 +215,33 @@ def test_beamlist_errors(beam_objs):
 
 def test_beamlist_consistency(beam_objs):
     newbeams = copy.deepcopy(beam_objs)
-    beamlist = pyuvsim.BeamList(newbeams[:2])
-
-    beamlist.check_consistency()
+    
+    # Does check, but raises no error
+    pyuvsim.BeamList(newbeams[:2])
 
     with pytest.raises(pyuvsim.BeamConsistencyError):
         # Raises because analytic beams have no Nfeeds
-        beamlist = pyuvsim.BeamList(newbeams[:3])
-        beamlist.check_consistency()
+        pyuvsim.BeamList(newbeams[:3])
+
+def test_beamlist_consistency_properties(beam_objs):
+    newbeams = copy.deepcopy(beam_objs)
+    beamlist = pyuvsim.BeamList(newbeams[:2])
+    assert beamlist.x_orientation == newbeams[0].x_orientation
+
+def test_beamlist_consistency_stringmode(beam_objs):
+    newbeams = copy.deepcopy(beam_objs)
+    beamlist = pyuvsim.BeamList(newbeams[:2])
+    beamlist.set_str_mode()
+    beamlist.check_consistency(force=True)
+    assert beamlist.string_mode
+    with pytest.warns(UserWarning) as record:
+        beamlist.check_consistency(force=False)
+        if not record:
+            pytest.fail("Expected a warning!")
+
+
+    beamlist = pyuvsim.BeamList(newbeams[:3], check=False)
+    beamlist.set_str_mode()
+    
+    with pytest.raises(pyuvsim.BeamConsistencyError):
+        pyuvsim.BeamList(beamlist._str_beam_list, force_check=True)

--- a/pyuvsim/tests/test_telescope.py
+++ b/pyuvsim/tests/test_telescope.py
@@ -241,3 +241,18 @@ def test_beamlist_consistency_stringmode(beam_objs):
     beamlist.set_str_mode()
 
     pyuvsim.BeamList(beamlist._str_beam_list, check=True, force_check=True)
+
+
+def test_empty_beamlist():
+    a = pyuvsim.BeamList(check=False)
+    assert a.x_orientation is None
+    assert a.beam_type is None
+
+
+def test_powerbeam_consistency(beam_objs):
+    newbeams = copy.deepcopy(beam_objs[:2])
+    for beam in newbeams:
+        beam.efield_to_power()
+
+    beamlist = pyuvsim.BeamList(newbeams)
+    beamlist.check_consistency()

--- a/pyuvsim/tests/test_telescope.py
+++ b/pyuvsim/tests/test_telescope.py
@@ -191,7 +191,7 @@ def test_beamlist_errors(beam_objs):
     newbeams[0].x_orientation = None
     with pytest.raises(
         BeamConsistencyError,
-        match='x_orientation of beam 1 is not consistent with beam 2'
+        match='x_orientation of beam 2 is not consistent with beam 1'
     ):
         pyuvsim.BeamList(newbeams, check=True)
 

--- a/pyuvsim/tests/test_telescope.py
+++ b/pyuvsim/tests/test_telescope.py
@@ -211,3 +211,15 @@ def test_beamlist_errors(beam_objs):
     tel0 = pyuvsim.Telescope('tel0', array_location, newbeams)
     tel1 = pyuvsim.Telescope('tel1', array_location, beam_objs)
     assert tel0 != tel1
+
+
+def test_beamlist_consistency(beam_objs):
+    newbeams = copy.deepcopy(beam_objs)
+    beamlist = pyuvsim.BeamList(newbeams[:2])
+
+    beamlist.check_consistency()
+
+    with pytest.raises(pyuvsim.BeamConsistencyError):
+        # Raises because analytic beams have no Nfeeds
+        beamlist = pyuvsim.BeamList(newbeams[:3])
+        beamlist.check_consistency()

--- a/pyuvsim/tests/test_telescope.py
+++ b/pyuvsim/tests/test_telescope.py
@@ -215,7 +215,7 @@ def test_beamlist_errors(beam_objs):
 
 def test_beamlist_consistency(beam_objs):
     newbeams = copy.deepcopy(beam_objs)
-    
+
     # Does check, but raises no error
     pyuvsim.BeamList(newbeams[:2])
 
@@ -223,10 +223,12 @@ def test_beamlist_consistency(beam_objs):
         # Raises because analytic beams have no Nfeeds
         pyuvsim.BeamList(newbeams[:3])
 
+
 def test_beamlist_consistency_properties(beam_objs):
     newbeams = copy.deepcopy(beam_objs)
     beamlist = pyuvsim.BeamList(newbeams[:2])
     assert beamlist.x_orientation == newbeams[0].x_orientation
+
 
 def test_beamlist_consistency_stringmode(beam_objs):
     newbeams = copy.deepcopy(beam_objs)
@@ -239,9 +241,8 @@ def test_beamlist_consistency_stringmode(beam_objs):
         if not record:
             pytest.fail("Expected a warning!")
 
-
     beamlist = pyuvsim.BeamList(newbeams[:3], check=False)
     beamlist.set_str_mode()
-    
+
     with pytest.raises(pyuvsim.BeamConsistencyError):
         pyuvsim.BeamList(beamlist._str_beam_list, force_check=True)

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -650,7 +650,7 @@ def run_uvdata_uvsim(input_uv, beam_list, beam_dict=None, catalog=None, quiet=Fa
 
     # In case the user created the beam list without checking consistency:
     beam_list.check_consistency()
-    
+
     if beam_list.beam_type != 'efield':
         raise ValueError("Beam type must be efield!")
 

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -648,6 +648,12 @@ def run_uvdata_uvsim(input_uv, beam_list, beam_dict=None, catalog=None, quiet=Fa
     # Construct beam objects from strings
     beam_list.set_obj_mode(use_shared_mem=True)
 
+    # In case the user created the beam list without checking consistency:
+    beam_list.check_consistency()
+    
+    if beam_list.beam_type != 'efield':
+        raise ValueError("Beam type must be efield!")
+
     # Estimating required memory to decide how to split source array.
     mem_avail = (simutils.get_avail_memory()
                  - mpi.get_max_node_rss(return_per_node=True) * 2**30)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds the `check_consistency` method on the `BeamList` class, which can be manually called to check that all of the consistuent beams have some consistent properties. It also adds a test for both passing and failing cases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
In simulation, often you're assuming that all your beams come from the same telescope, and have some set of similar properties (eg, all are efield/power and all have the same set of polarizations/feeds etc). This is not *always* the case, or at least, more general simulators will allow different beams to have different properties and have ways of simulating each one independently. However, many simulators will want some way to check consistency before going off and running. This adds  a simple method that can be called in such a case.

I am not the expert on what people may or may not want to check for. I added a keyword `check_pols` to check for polarization-related stuff (which is almost everything) because I don't know if all simulators will want to check for that. There are other UVBeam parameters that I ignored because I don't know enough about them, but perhaps should be added to the checks (eg. Ncomponents_vec and frequency-related parameters). 

I also opted to raise an error if one of the beams doesn't *have* a certain parameter but the rest do, as well as if they both have the parameter but they're different. I'm not sure this is always the right thing to do. For instance, AnalyticBeam objects don't define `Nfeeds` even though they're `efield` beams by default. Not sure how that works.

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the documentation to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).

