### PR TITLE
Make --with-inputs a proper flag not a boolean input.

### DIFF
--- a/reference_simulations/download_latest_data.py
+++ b/reference_simulations/download_latest_data.py
@@ -24,7 +24,7 @@ parser.add_argument(
 parser.add_argument(
     "--with-inputs",
     dest="inputs",
-    type=bool,
+    action="store_true",
     help=(
         "Additionally download input data from the google drive for simulations whose "
         "inputs cannot be stored on github directly."


### PR DESCRIPTION
the script to download the reference data and inputs should have use a `store_true` action for the`--with-inputs` command.