### PR TITLE
Filter warnings from SkyModel in deprecated `return_recarray` option

### DIFF
--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1047,8 +1047,10 @@ def initialize_catalog_from_params(
         warnings.warn("initialize_catalog_from_params will return a SkyModel instance, not "
                       "a recarray, by default in version 1.3. Set keyword "
                       "`return_recarray=True` to ensure recarray is returned.",
-                      PendingDeprecationWarning)
-        sky = sky.to_recarray()
+                      DeprecationWarning)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            sky = sky.to_recarray()
 
     if return_catname:
         return sky, source_list_name

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -169,11 +169,10 @@ def test_catalog_from_params(horizon_buffer):
     if horizon_buffer:
         source_dict["horizon_buffer"] = 0.04364
     with uvtest.check_warnings(
-        [UserWarning, PendingDeprecationWarning, DeprecationWarning, DeprecationWarning],
+        [UserWarning, DeprecationWarning, DeprecationWarning],
         match=[
             "No array_location specified. Defaulting to the HERA site.",
             "initialize_catalog_from_params will return a SkyModel instance",
-            "recarray flux columns will no longer be labeled",
             "The return_catname parameter currently defaults to True, but starting in"
             "version 1.4 it will default to False.",
         ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a warnings filter to eliminate extra deprecation warnings coming from SkyModel.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
SkyModel is adding more deprecation warnings, but this is in code that is already deprecated in pyuvsim, so we don't need multiple warnings.

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [ ] I have checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).
