### PR TITLE
generalizing jones matrix for Nfeeds=1,2

### DIFF
--- a/pyuvsim/antenna.py
+++ b/pyuvsim/antenna.py
@@ -43,7 +43,7 @@ class Antenna:
         """
         Calculate the jones matrix for this antenna in the direction of sources.
 
-        A 2 x 2 x Nsources array of Efield vectors in Az/Alt.
+        A Nfeeds x 2 x Nsources array of Efield vectors in Az/Alt.
 
         Parameters
         ----------
@@ -67,7 +67,7 @@ class Antenna:
         Returns
         -------
         jones_matrix : array_like of float
-            Jones matricies for each source location, shape (2,2, Ncomponents). The
+            Jones matricies for each source location, shape (Nfeeds,2, Ncomponents). The
             first axis is feed, the second axis is vector component on the sky in az/za.
 
         """
@@ -111,17 +111,14 @@ class Antenna:
         interp_data, _ = beam.interp(**interp_kwargs)
 
         Ncomponents = source_za.shape[-1]
-
+        Nfeeds = interp_data.shape[2]
         # interp_data has shape:
         #   (Naxes_vec, Nspws, Nfeeds, 1 (freq),  Ncomponents (source positions))
-        jones_matrix = np.zeros((2, 2, Ncomponents), dtype=complex)
+        jones_matrix = np.zeros((Nfeeds, 2, Ncomponents), dtype=complex)
 
         # first axis is feed, second axis is theta, phi (opposite order of beam!)
-        jones_matrix[0, 0] = interp_data[1, 0, 0, 0, :]
-        jones_matrix[1, 1] = interp_data[0, 0, 1, 0, :]
-        jones_matrix[0, 1] = interp_data[0, 0, 0, 0, :]
-        jones_matrix[1, 0] = interp_data[1, 0, 1, 0, :]
-
+        jones_matrix[:, 0] = interp_data[1, 0, :, 0, :]
+        jones_matrix[:, 1] = interp_data[0, 0, :, 0, :]
         return jones_matrix
 
     def __eq__(self, other):

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -348,8 +348,13 @@ class UVEngine:
         # Sum over source component axis:
         vij = np.sum(vij, axis=2)
 
-        # Reshape to be [xx, yy, xy, yx]
-        vis_vector = np.asarray([vij[0, 0], vij[1, 1], vij[0, 1], vij[1, 0]])
+        Nfeeds = vij.shape[0]
+        assert (Nfeeds<=2)
+        # Reshape to be [xx] for one feed or [xx, yy, xy, yx] for two feeds
+        if Nfeeds == 1:
+            vis_vector = np.asarray([vij[0,0]])
+        elif Nfeeds == 2:
+            vis_vector = np.asarray([vij[0, 0], vij[1, 1], vij[0, 1], vij[1, 0]])
         return vis_vector
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes the jones matrix routine to (Nfeeds,2) instead of (2,2) generalizing to any Nfeeds. Down the line Nfeeds can still be only 1 or 2, but this can be changed. This is only a proposal.

## Description
See file changes - pretty obvious. Still specialized for theta-phi coordinate system.
