### PR TITLE
Sim Setup Performance Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ docs/index.rst
 # exclude project specific files
 pyuvsim/GIT_INFO
 pyuvsim/data/temporary_test_data/*
+.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "esbonio.sphinx.confDir": ""
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `reorder_kw` option to `initialize_uvdata_from_params` function.
 - `check_kw` option to `initialize_uvdata_from_params` function.
 - `select:` parameter to obsparam file definition for `telescope:`.
-- 
+-
 ## [1.2.4] - 2022-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [Unreleased]
 
 ### Changed
-- Use future array shapes on UVBeam objects.
-- Require pyuvdata >= 2.2.10
 - Initial ordering of blt axis in `initialize_uvdata_from_params`
   (unchanged output by default).
+- Use future array shapes on UVBeam objects.
+- Require pyuvdata >= 2.2.10
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `reorder_kw` option to `initialize_uvdata_from_params` function.
 - `check_kw` option to `initialize_uvdata_from_params` function.
 - `select:` parameter to obsparam file definition for `telescope:`.
--
+
 ## [1.2.4] - 2022-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@
 - `reorder_kw` option to `initialize_uvdata_from_params` function.
 - `check_kw` option to `initialize_uvdata_from_params` function.
 - `select:` parameter to obsparam file definition for `telescope:`.
-
-
+- 
 ## [1.2.4] - 2022-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### Changed
 - Use future array shapes on UVBeam objects.
 - Require pyuvdata >= 2.2.10
+- Initial ordering of blt axis in `initialize_uvdata_from_params`
+  (unchanged output by default).
+
+
+### Added
+- `reorder_kw` option to `initialize_uvdata_from_params` function.
+- `check_kw` option to `initialize_uvdata_from_params` function.
+- `select:` parameter to obsparam file definition for `telescope:`.
 
 
 ## [1.2.4] - 2022-06-01

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Required:
 * astropy>=5.0.4
 * numpy>=1.15
 * psutil
-* pyradiosky>=0.1.0
+* pyradiosky>=0.1.0<0.2
 * pyuvdata>=2.2.10
 * pyyaml>=5.1
 * scipy>1.0.1

--- a/ci/min_deps.yaml
+++ b/ci/min_deps.yaml
@@ -16,4 +16,4 @@ dependencies:
   - setuptools_scm
   - psutil
   - pip:
-    - pyradiosky>=0.1.2
+    - pyradiosky>=0.1.2,<0.2

--- a/ci/publish.yaml
+++ b/ci/publish.yaml
@@ -13,5 +13,5 @@ dependencies:
   - setuptools_scm
   - psutil
   - pip:
-    - pyradiosky>=0.1.2
+    - pyradiosky>=0.1.2,<0.2
     - pep517

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -19,6 +19,6 @@ dependencies:
   - scipy
   - setuptools_scm
   - pip:
-    - pyradiosky>=0.1.2
+    - pyradiosky>=0.1.2,<0.2
     - lunarsky
     - git+https://github.com/aelanman/analytic_diffuse

--- a/docs/example_configs/bl_lite_mixed.yaml
+++ b/docs/example_configs/bl_lite_mixed.yaml
@@ -14,3 +14,5 @@ spline_interp_opts:
 freq_interp_kind: 'cubic'
 telescope_location: (-30.72152777777791, 21.428305555555557, 1073.0000000093132)
 telescope_name: BLLITE
+select:
+  freq_buffer: 1000000  # 1 MHz either side of simulated frequencies

--- a/docs/parameter_files.rst
+++ b/docs/parameter_files.rst
@@ -202,6 +202,11 @@ Telescope Configuration
     The `spline_interp_opts` keyword lets the user set the order on the angular
     interpolating polynomial spline function. By default, it is cubic.
 
+    The `select: freq_buffer` (optional) option allows for doing partial reading of a
+    UVBeam file. Only frequencies within `freq_buffer` of the min and max of the
+    simulated frequencies will be read during setup. This can help reduce peak memory
+    usage.
+
     Analytic beams may require additional parameters.
 
     - uniform = The same response in all directions. No additional parameters.

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,6 @@ dependencies:
   - setuptools_scm
   - sphinx
   - pip:
-    - pyradiosky>=0.1.2
+    - pyradiosky>=0.1.2<0.2
     - lunarsky
     - git+https://github.com/aelanman/analytic_diffuse

--- a/pyuvsim/antenna.py
+++ b/pyuvsim/antenna.py
@@ -138,6 +138,7 @@ class Antenna:
         jones_matrix = np.zeros((2, 2, Ncomponents), dtype=complex)
 
         # first axis is feed, second axis is theta, phi (opposite order of beam!)
+        print(interp_data.shape)
         jones_matrix[0, 0] = interp_data[1, 0, 0, :]
         jones_matrix[1, 1] = interp_data[0, 1, 0, :]
         jones_matrix[0, 1] = interp_data[0, 0, 0, :]

--- a/pyuvsim/data/telescope_config_6ant_freqbuf.yaml
+++ b/pyuvsim/data/telescope_config_6ant_freqbuf.yaml
@@ -3,3 +3,5 @@ beam_paths:
   0: ../data/HERA_NicCST.uvbeam
 telescope_location: (-30.721527777777911, 21.428305555555557, 1073.0000000093132)
 telescope_name: HERA
+select:
+  freq_buffer: 1000000  # 1 MHz either side of simulated frequencies.

--- a/pyuvsim/data/telescope_config_6ant_freqbuf.yaml
+++ b/pyuvsim/data/telescope_config_6ant_freqbuf.yaml
@@ -1,0 +1,7 @@
+Nants: 6
+beam_paths:
+  0: ../data/HERA_NicCST.uvbeam
+telescope_location: (-30.721527777777911, 21.428305555555557, 1073.0000000093132)
+telescope_name: HERA
+select:
+  freq_buffer: 1000000  # 1 MHz either side of simulated frequencies.

--- a/pyuvsim/data/telescope_config_6ant_freqbuf.yaml
+++ b/pyuvsim/data/telescope_config_6ant_freqbuf.yaml
@@ -3,5 +3,3 @@ beam_paths:
   0: ../data/HERA_NicCST.uvbeam
 telescope_location: (-30.721527777777911, 21.428305555555557, 1073.0000000093132)
 telescope_name: HERA
-select:
-  freq_buffer: 1000000  # 1 MHz either side of simulated frequencies.

--- a/pyuvsim/data/test_config/obsparam_diffuse_sky_freqbuf.yaml
+++ b/pyuvsim/data/test_config/obsparam_diffuse_sky_freqbuf.yaml
@@ -1,0 +1,22 @@
+filing:
+  outdir: '.'
+  outfile_name: 'sim_results.uvfits'
+freq:
+  Nfreqs: 1
+  bandwidth: 800000.0
+  start_freq: 100000000.0
+sources:
+  catalog: 'mock'
+  time: 2457458.1738949567
+  mock_arrangement: 'diffuse'
+  diffuse_model: 'monopole'
+  map_nside: 128
+telescope:
+  telescope_config_name: '28m_triangle_10time_10chan.yaml'
+  array_layout: 'triangle_bl_layout.csv'
+  select:
+    freq_buffer: 1000000.0  # Restrict beam to read frequencies within 1MHz of sim freqs.
+time:
+  Ntimes: 1
+  integration_time: 11.0
+  start_time: 2457458.1738949567

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1739,11 +1739,9 @@ def initialize_uvdata_from_params(
 
     # Parse polarizations
     if uvparam_dict.get('polarization_array', None) is None:
-        print("Doing this...")
         uvparam_dict['polarization_array'] = np.array([-5, -6, -7, -8])
 
     if 'Npols' not in uvparam_dict:
-        print("UVparam_dict: pol", uvparam_dict['polarization_array'])
         uvparam_dict['Npols'] = len(uvparam_dict['polarization_array'])
 
     if version.parse(pyuvdata.__version__) > version.parse("2.2.12"):
@@ -2224,7 +2222,7 @@ def uvdata_to_telescope_config(
     with open(os.path.join(path_out, telescope_config_name), 'w+') as yfile:
         yaml.dump(yaml_dict, yfile, default_flow_style=False)
 
-    print('Path: {}, telescope_config: {}, layout: {}'.format(
+    logger.info('Path: {}, telescope_config: {}, layout: {}'.format(
         path_out, telescope_config_name, layout_csv_name)
     )
 

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1811,6 +1811,11 @@ def initialize_uvdata_from_params(
 
     # add other required metadata to allow select to work without errors
     # these will all be overwritten in uvsim._complete_uvdata, so it's ok to hardcode them here
+    memlog("After Metadata")
+    logger.info(f"  Baseline Array: {uv_obj.baseline_array.nbytes / 1024**3:.2f} GB")
+    logger.info(f"      Time Array: {uv_obj.time_array.nbytes / 1024**3:.2f} GB")
+    logger.info(f"Integration Time: {uv_obj.integration_time.nbytes / 1024**3:.2f} GB")
+    logger.info(f"       Ant1Array: {uv_obj.ant_1_array.nbytes / 1024**3:.2f} GB")
 
     _set_lsts_on_uvdata(uv_obj)
     memlog("After Set LSTs")

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1860,7 +1860,9 @@ def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None
     # we construct uvdata objects in (time, ant1) order
     # but the simulator will force (time, baseline) later
     # so order this now so we don't get any warnings.
-    reorder_kw = reorder_kw or {'order': 'time', 'minor_order': 'baseline'}
+    if reorder_kw is None:
+        reorder_kw = {'order': 'time', 'minor_order': 'baseline'}
+
     if reorder_kw:
         uv_obj.reorder_blts(**reorder_kw)
 

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1692,7 +1692,9 @@ def initialize_uvdata_from_params(obs_params, return_beams=None):
     freq_buffer = beamselect.pop("freq_buffer", None)
     if freq_buffer:
         freq_range = (freq_array.min() - freq_buffer, freq_array.max() + freq_buffer)
-
+    else:
+        freq_range = None
+        
     tele_params, beam_list, beam_dict = parse_telescope_params(tele_dict, config_path=param_dict[
         'config_path'], freq_range=freq_range)
     uvparam_dict.update(tele_params)

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1682,7 +1682,7 @@ def initialize_uvdata_from_params(obs_params, return_beams=None):
     # Parse frequency structure
     freq_dict = param_dict['freq']
     uvparam_dict.update(parse_frequency_params(freq_dict))
-    freq_array = freq_dict['freq_array']
+    freq_array = uvparam_dict['freq_array']
     memlog("After Freq Array")
 
     # Parse telescope parameters

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -13,6 +13,7 @@ objects and empty :class:`pyuvdata.UVData` objects from configuration files.
 """
 import ast
 import copy
+import logging
 import os
 import shutil
 import warnings
@@ -27,10 +28,6 @@ from astropy.coordinates import (ICRS, AltAz, Angle, EarthLocation, Latitude,
 from packaging import version  # packaging is installed with setuptools
 from pyuvdata import UVData
 from pyuvdata import utils as uvutils
-from astropy.coordinates import Angle, EarthLocation, Latitude, Longitude, AltAz, ICRS
-import astropy.units as units
-import pyradiosky
-import logging
 
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1877,6 +1877,8 @@ def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None
 
     uv_obj.check()
 
+    memlog("After Check")
+
     if return_beams:
         return uv_obj, beam_list, beam_dict
     else:

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1771,7 +1771,7 @@ def initialize_uvdata_from_params(
 
     bls = np.array(
         [
-            uv_obj.antnums_to_baseline(uv_obj.antenna_numbers[j], uv_obj.antenna_numbers[i])
+            uv_obj.antnums_to_baseline(uv_obj.antenna_numbers[i], uv_obj.antenna_numbers[j])
             for i in range(0, uv_obj.Nants_data)
             for j in range(i, uv_obj.Nants_data)
         ]

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1737,13 +1737,16 @@ def initialize_uvdata_from_params(
 
     # There does not seem to be any way to get polarization_array into uvparam_dict, so
     # let's add it explicitly.
-    if "polarization_array" in param_dict:
+    if param_dict.get("polarization_array", None) is not None:
         uvparam_dict['polarization_array'] = np.array(param_dict['polarization_array'])
 
     # Parse polarizations
     if uvparam_dict.get('polarization_array', None) is None:
+        print("Doing this...")
         uvparam_dict['polarization_array'] = np.array([-5, -6, -7, -8])
+
     if 'Npols' not in uvparam_dict:
+        print("UVparam_dict: pol", uvparam_dict['polarization_array'])
         uvparam_dict['Npols'] = len(uvparam_dict['polarization_array'])
 
     if version.parse(pyuvdata.__version__) > version.parse("2.2.12"):
@@ -1779,7 +1782,7 @@ def initialize_uvdata_from_params(
 
     bls = np.array(
         [
-            uv_obj.antnums_to_baseline(uv_obj.antenna_numbers[i], uv_obj.antenna_numbers[j])
+            uv_obj.antnums_to_baseline(uv_obj.antenna_numbers[j], uv_obj.antenna_numbers[i])
             for i in range(0, uv_obj.Nants_data)
             for j in range(i, uv_obj.Nants_data)
         ]

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1637,7 +1637,7 @@ def memlog(msg):
 
 
 def initialize_uvdata_from_params(
-    obs_params, return_beams=None, reorder_kw=None, check_kw=None, set_uvws: bool = True
+    obs_params, return_beams=None, reorder_kw=None, check_kw=None
 ):
     """
     Construct a :class:`pyuvdata.UVData` object from parameters in a valid yaml file.
@@ -1813,8 +1813,9 @@ def initialize_uvdata_from_params(
     # these will all be overwritten in uvsim._complete_uvdata, so it's ok to hardcode them here
 
     _set_lsts_on_uvdata(uv_obj)
-    if set_uvws:
-        uv_obj.set_uvws_from_antenna_positions()
+    memlog("After Set LSTs")
+
+    uv_obj.set_uvws_from_antenna_positions()
     memlog("After Set UVWs")
 
     uv_obj.history = ''

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1158,7 +1158,7 @@ def _construct_beam_list(beam_ids, telconfig, freq_range=None):
 
             beam_list.append(beam_model)
 
-    select = telconfig['select']
+    select = telconfig.pop('select', {})
     if freq_range is not None:
         select['freq_range'] = freq_range
 

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1730,7 +1730,7 @@ def initialize_uvdata_from_params(
     # There does not seem to be any way to get polarization_array into uvparam_dict, so
     # let's add it explicitly.
     if "polarization_array" in param_dict:
-        uvparam_dict['polarization_array'] = param_dict['polarization_array']
+        uvparam_dict['polarization_array'] = np.array(param_dict['polarization_array'])
 
     # Parse polarizations
     if uvparam_dict.get('polarization_array', None) is None:

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1782,9 +1782,10 @@ def initialize_uvdata_from_params(
     uv_obj.time_array = np.repeat(uv_obj.time_array, uv_obj.Nbls)
     uv_obj.integration_time = np.repeat(uv_obj.integration_time, uv_obj.Nbls * uv_obj.Ntimes)
     uv_obj.Nblts = uv_obj.Nbls * uv_obj.Ntimes
-
+    uv_obj.blt_order = ('time', 'ant1')
     uv_obj.ant_1_array, uv_obj.ant_2_array = uv_obj.baseline_to_antnums(uv_obj.baseline_array)
 
+    logger.info(f"BLT-ORDER: {uv_obj.blt_order}")
     if version.parse(pyuvdata.__version__) > version.parse("2.2.12"):
 
         cat_id = uv_obj._add_phase_center(
@@ -1809,9 +1810,11 @@ def initialize_uvdata_from_params(
     logger.info(f"       Ant1Array: {uv_obj.ant_1_array.nbytes / 1024**3:.2f} GB")
 
     _set_lsts_on_uvdata(uv_obj)
+    logger.info(f"BLT-ORDER: {uv_obj.blt_order}")
     logger.info("Set LSTs")
 
     uv_obj.set_uvws_from_antenna_positions()
+    logger.info(f"BLT-ORDER: {uv_obj.blt_order}")
     logger.info("Set UVWs")
 
     uv_obj.history = ''
@@ -1871,9 +1874,13 @@ def initialize_uvdata_from_params(
     if reorder_kw is None:
         reorder_kw = {'order': 'time', 'minor_order': 'baseline'}
 
-    if reorder_kw:
+    if reorder_kw and reorder_kw != {
+        'order': uv_obj.blt_order[0],
+        'minor_order': uv_obj.blt_order[1]
+    }:
         uv_obj.reorder_blts(**reorder_kw)
 
+    logger.info(f"BLT-ORDER: {uv_obj.blt_order}")
     logger.info("After Re-order BLTS")
 
     if check_kw is None:
@@ -1881,7 +1888,7 @@ def initialize_uvdata_from_params(
     uv_obj.check(**check_kw)
 
     logger.info("After Check")
-
+    logger.info(f"BLT-ORDER: {uv_obj.blt_order}")
     if return_beams:
         return uv_obj, beam_list, beam_dict
     else:

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1182,7 +1182,8 @@ def parse_telescope_params(tele_params, config_path='', freq_range=None):
     config_path : str
         Path to directory holding configuration and layout files.
     freq_buffer : float
-        If given, 
+        If given, select frequencies on reading the beam.
+
     Returns
     -------
     param_dict : dict

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1187,7 +1187,7 @@ def parse_telescope_params(tele_params, config_path='', freq_range=None):
         https://pyuvsim.readthedocs.io/en/latest/parameter_files.html#telescope-configuration
     config_path : str
         Path to directory holding configuration and layout files.
-    freq_buffer : float
+    freq_range : float
         If given, select frequencies on reading the beam.
 
     Returns
@@ -1651,6 +1651,14 @@ def initialize_uvdata_from_params(
     return_beams : bool
         Option to return the beam_list and beam_dict. Currently defaults to True, but
         will default to False starting in version 1.4.
+    reorder_kw : dict (optional)
+        Keyword arguments to send to the ``uvdata.reorder_blts`` method at the end of
+        the setup process. Typical parameters include "order" and "minor_order". Default
+        values are ``order='time'`` and ``minor_order='baseline'``.
+    check_kw : dict (optional)
+        Keyword arguments to send to the ``uvdata.check()`` method at the end of the
+        setup process. Typical parameters include `run_check_acceptability` and
+        `check_extra`, which are both True by default.
 
     Returns
     -------

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1636,7 +1636,9 @@ def memlog(msg):
     logger.info(f"{msg:>25}: {c / 1024**3:.2f} | {p/1024**3:.2f} GB")
 
 
-def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None):
+def initialize_uvdata_from_params(
+    obs_params, return_beams=None, reorder_kw=None, check_kw=None, set_uvws: bool = True
+):
     """
     Construct a :class:`pyuvdata.UVData` object from parameters in a valid yaml file.
 
@@ -1810,7 +1812,9 @@ def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None
     # add other required metadata to allow select to work without errors
     # these will all be overwritten in uvsim._complete_uvdata, so it's ok to hardcode them here
 
-    uv_obj.set_uvws_from_antenna_positions()
+    _set_lsts_on_uvdata(uv_obj)
+    if set_uvws:
+        uv_obj.set_uvws_from_antenna_positions()
     memlog("After Set UVWs")
 
     uv_obj.history = ''
@@ -1875,7 +1879,9 @@ def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None
 
     memlog("After Re-order BLTS")
 
-    uv_obj.check()
+    if check_kw is None:
+        check_kw = {}
+    uv_obj.check(**check_kw)
 
     memlog("After Check")
 
@@ -1885,7 +1891,7 @@ def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None
         return uv_obj
 
 
-def _complete_uvdata(uv_in, inplace=False):
+def _complete_uvdata(uv_in, inplace=False, check_kw=None):
     """
     Fill out all required parameters of a :class:`pyuvdata.UVData` object.
 
@@ -1924,7 +1930,10 @@ def _complete_uvdata(uv_in, inplace=False):
 
     uv_obj.extra_keywords = {}
 
-    uv_obj.check()
+    if check_kw is not False:
+        if check_kw is None:
+            check_kw = {}
+        uv_obj.check(**check_kw)
 
     return uv_obj
 

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -1688,7 +1688,7 @@ def initialize_uvdata_from_params(obs_params, return_beams=None):
     # Parse telescope parameters
     tele_dict = param_dict['telescope']
     uvparam_dict.update(tele_dict)
-    beamselect = tele_dict['select']
+    beamselect = tele_dict.pop('select', {})
     freq_buffer = beamselect.pop("freq_buffer", None)
     if freq_buffer:
         freq_range = (freq_array.min() - freq_buffer, freq_array.max() + freq_buffer)

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -31,6 +31,7 @@ from astropy.coordinates import Angle, EarthLocation, Latitude, Longitude, AltAz
 import astropy.units as units
 import pyradiosky
 import tracemalloc
+import logging
 
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 
@@ -56,6 +57,8 @@ except ImportError:
 
     mpi = None
 from .utils import check_file_exists_and_increment
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_layout_csv(layout_csv):
@@ -1630,7 +1633,7 @@ def time_array_to_params(time_array):
 def memlog(msg):
     """Print a message about memory usage."""
     c, p = tracemalloc.get_traced_memory()
-    print(f"{msg:>25}: {c / 1024**3:.2f} | {p/1024**3:.2f} GB")
+    logger.info(f"{msg:>25}: {c / 1024**3:.2f} | {p/1024**3:.2f} GB")
 
 
 def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None):
@@ -1668,6 +1671,8 @@ def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None
     if not tracemalloc.is_tracing():
         tracemalloc.start()
 
+    memlog("Start")
+
     if return_beams is None:
         warnings.warn(
             "The return_beams parameter currently defaults to True, but starting in"
@@ -1682,6 +1687,7 @@ def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None
     else:
         param_dict = copy.deepcopy(obs_params)
 
+    memlog("After obsparam read")
     # Parse frequency structure
     freq_dict = param_dict['freq']
     uvparam_dict.update(parse_frequency_params(freq_dict))
@@ -1855,6 +1861,7 @@ def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None
 
         if redundant_threshold is not None:
             uv_obj.compress_by_redundancy(tol=redundant_threshold)
+
     memlog("After Select")
 
     # we construct uvdata objects in (time, ant1) order
@@ -1866,7 +1873,7 @@ def initialize_uvdata_from_params(obs_params, return_beams=None, reorder_kw=None
     if reorder_kw:
         uv_obj.reorder_blts(**reorder_kw)
 
-    memlog("After Re-order BLTS=s")
+    memlog("After Re-order BLTS")
 
     uv_obj.check()
 

--- a/pyuvsim/telescope.py
+++ b/pyuvsim/telescope.py
@@ -56,6 +56,10 @@ class BeamList:
         Passing in a mixture of strings and objects will error.
     uvb_params : dict (optional)
         Options to set uvb_params, overriding settings from passed-in UVBeam objects.
+    select_params : dict (optional)
+        A dictionary that can contain parameters for selecting parts of the beam to
+        read. Example keys include ``freq_range`` and ``za_range``. Note that these
+        will only be used for beamfits format files.
     check : bool
         Whether to perform a consistency check on the beams (i.e. asserting that several
         of their defining parameters are the same for all beams in the list).

--- a/pyuvsim/telescope.py
+++ b/pyuvsim/telescope.py
@@ -87,7 +87,7 @@ class BeamList:
         self,
         beam_list=None,
         uvb_params=None,
-        select_params: dict[str: tuple[float, float]]=None,
+        select_params: dict[str: tuple[float, float]] = None,
         check: bool = True,
         force_check: bool = False
     ):

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -553,8 +553,10 @@ def test_param_reader():
 
     # the old object was written before ordering was enforced
     assert hera_uv.blt_order != uv_obj.blt_order
+    hera_uv.reorder_blts("time", "ant1")
     hera_uv.reorder_blts("time", "baseline")
 
+    uv_obj.reorder_blts("time", "baseline")
     # renumber/rename the phase centers so the equality check will pass.
     if version.parse(pyuvdata.__version__) > version.parse("2.2.12"):
         uv_obj._consolidate_phase_center_catalogs(other=hera_uv, ignore_name=True)

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1414,7 +1414,7 @@ def test_beamlist_init_freqrange():
 
     # How the beam attributes should turn out for this file:
     assert isinstance(beam_list[0], UVBeam)
-    assert len(beam_list[0].freq_array[0]) == 2
+    assert len(beam_list[0].freq_array) == 2
 
 
 @pytest.mark.filterwarnings("ignore:Cannot check consistency of a string-mode BeamList")

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1398,8 +1398,6 @@ def test_beamlist_init():
     assert beam_list[5].type == 'gaussian'
     assert beam_list[5].diameter == 12
 
-    print(beam_list[0].freq_array / 1e6)
-
 
 @pytest.mark.filterwarnings("ignore:Cannot check consistency of a string-mode BeamList")
 def test_beamlist_init_freqrange():

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -1657,6 +1657,7 @@ def test_set_lsts_errors():
         pyuvsim.simsetup._set_lsts_on_uvdata(uv0)
 
 
+@pytest.mark.filterwarnings("ignore:Cannot check consistency of a string-mode BeamList")
 def test_simsetup_with_freq_buffer():
     fl = os.path.join(SIM_DATA_PATH, 'test_config', 'obsparam_diffuse_sky_freqbuf.yaml')
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup_args = {
         'astropy>=5.0.4',
         'numpy>=1.15',
         'psutil',
-        'pyradiosky>=0.1.2<0.2',
+        'pyradiosky>=0.1.2,<0.2',
         'pyuvdata>=2.2.10',
         'pyyaml',
         'scipy',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup_args = {
         'astropy>=5.0.4',
         'numpy>=1.15',
         'psutil',
-        'pyradiosky>=0.1.2',
+        'pyradiosky>=0.1.2<0.2',
         'pyuvdata>=2.2.10',
         'pyyaml',
         'scipy',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds the following performance-enhancing features in the context of setting up a simulation from config:

1. Ability to do partial reading of beams (if they are beamfits format), to reduce peak RAM usage. Principally, it adds the ability to specify `select:` in the telescope YAML file, to which can be added `freq_range`, `az_range` and `za_range`. For instance, if a simulator only requires the beam above the horizon, they may want to set `za_range: [0, 95]` (where we use 95 so that interpolation to the horizon doesn't quite hit the edge). It also adds the possibility of a `select:` parameter in the main obsparam file, under the `telescope:` heading. Here, I've only added one possible parameter to the `select:` heading, which is `freq_buffer`. If set, this will pass through its information so that only frequencies from `(freq_array.min - buffer, freq_array.max + buffer)` are read in (where `freq_array` is the UVData frequencies). It seems reasonable that only frequencies surrounding those that will actually be simulated should be read in (again, with some buffer to enable interpolation with k>1). 
2. Ability to turn off the checks on the built UVData object (especially the `run_check_acceptability` which can double peak RAM)
3. Ability to not reorder the blt axis after initial setup. While pyuvsim requires a re-ordering, other simulators do not, and doing so can triple the peak RAM at setup. 
4. Manually sets the `blt_order` attribute of the UVData upon setup, which can help simulators know if the blt axis needs to be reordered to suit their purposes.
5. Adds many `INFO`-level log-statements throughout the setup. These shouldn't general be shown, but can be switched on by the user in application code. I am open to suggestions on which of these statements are really necessary and whether you'd prefer a different log-level (or different logging mechanism entirely).

**NOTE**: this PR also pins pyradiosky<0.2, due to API changes in pyradiosky that break unrelated code in pyuvsim (unrelated to this PR, that is). That will be fixed by #417.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This PR was developed alongside trying to get the H4C simulations run on GPU (using `hera_sim` calling `vis_gpu`). The main concerns here were peak RAM usage and timing performance. 

The RAM usage is a particular concern because there is quite a limited amount of RAM available on the host of the GPU nodes (23.75GB). The simulations we're running are reasonably large (1 freq, 17280 times, 8000 baselines, 4 pols), but should easily fit in this amount of RAM. However, there were several problems with the setup that meant that the peak RAM would exceed this amount. This PR significantly reduces this peak RAM (although, in the end I still had to run the simulations in chunks of 5760 times each).

The wall-time performance is another concern that was previously overlooked. Simulations of this size on the CPU take ~10-20 hours, so the setup/write time is negligible. However, on the GPU, the simulation takes ~15min, which makes every minute of setup time undesirable. Using the changes in this PR (and some changes in `hera_sim` to accompany it) I was able to reduce setup/check/write time from ~30min to mere seconds. 

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the documentation to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).
