### PR TITLE
Remove handling for older pyuvdata versions in tests

### DIFF
--- a/pyuvsim/tests/test_run.py
+++ b/pyuvsim/tests/test_run.py
@@ -317,10 +317,8 @@ def test_sim_on_moon(future_shapes):
 
     # set the filename to make sure it ends up in the history,
     # remove the parameter file info from extra_keywords
-    if hasattr(uv_obj, "filename"):
-        # only exists in pyuvdata >= 2.2.5
-        uv_obj.filename = ["moon_sim"]
-        uv_obj._filename.form = (1,)
+    uv_obj.filename = ["moon_sim"]
+    uv_obj._filename.form = (1,)
     uv_obj.extra_keywords.pop('obsparam')
     uv_obj.extra_keywords.pop('telecfg')
     uv_obj.extra_keywords.pop('layout')
@@ -342,8 +340,7 @@ def test_sim_on_moon(future_shapes):
     assert uvutils._check_history_version(uv_out.history, pyradiosky.__version__)
     assert uvutils._check_history_version(uv_out.history, pyuvdata.__version__)
     assert uvutils._check_history_version(uv_out.history, pyuvsim.__version__)
-    if hasattr(uv_obj, "filename"):
-        assert uvutils._check_history_version(uv_out.history, uv_obj.filename[0])
+    assert uvutils._check_history_version(uv_out.history, uv_obj.filename[0])
     assert uvutils._check_history_version(uv_out.history, "Npus =")
 
     assert np.allclose(uv_out.data_array[:, :, 0], 0.5)

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -247,19 +247,10 @@ def test_gleam_catalog(filetype):
 
     warn_messages = ["No spectral_type specified for GLEAM, using 'flat'."]
     warnings = [UserWarning]
-    # The try/except can be removed once we require pyuvdata > 2.2.6
-    try:
-        with uvtest.check_warnings(warnings, match=warn_messages):
-            gleam_catalog = pyuvsim.simsetup.initialize_catalog_from_params(
-                gleam_param_filename, return_recarray=False, filetype=filetype, return_catname=False
-            )
-    except AssertionError:
-        warn_messages += ["distutils Version classes are deprecated."] * 8
-        warnings += [DeprecationWarning] * 8
-        with uvtest.check_warnings(warnings, match=warn_messages):
-            gleam_catalog = pyuvsim.simsetup.initialize_catalog_from_params(
-                gleam_param_filename, return_recarray=False, filetype=filetype, return_catname=False
-            )
+    with uvtest.check_warnings(warnings, match=warn_messages):
+        gleam_catalog = pyuvsim.simsetup.initialize_catalog_from_params(
+            gleam_param_filename, return_recarray=False, filetype=filetype, return_catname=False
+        )
 
     # flux cuts applied
     assert gleam_catalog.Ncomponents == 23
@@ -273,23 +264,12 @@ def test_gleam_catalog(filetype):
 
     warn_messages = ["No spectral_type specified for GLEAM, using 'flat'."]
     warnings = [UserWarning]
-    # The try/except can be removed once we require pyuvdata > 2.2.6
-    try:
-        with uvtest.check_warnings(
-            warnings, match=warn_messages
-        ):
-            gleam_catalog = pyuvsim.simsetup.initialize_catalog_from_params(
-                param_dict, return_recarray=False, filetype=filetype, return_catname=False
-            )
-    except AssertionError:
-        warn_messages += ["distutils Version classes are deprecated."] * 8
-        warnings += [DeprecationWarning] * 8
-        with uvtest.check_warnings(
-            warnings, match=warn_messages
-        ):
-            gleam_catalog = pyuvsim.simsetup.initialize_catalog_from_params(
-                param_dict, return_recarray=False, filetype=filetype, return_catname=False
-            )
+    with uvtest.check_warnings(
+        warnings, match=warn_messages
+    ):
+        gleam_catalog = pyuvsim.simsetup.initialize_catalog_from_params(
+            param_dict, return_recarray=False, filetype=filetype, return_catname=False
+        )
 
     assert gleam_catalog.Ncomponents == 50
 
@@ -437,19 +417,10 @@ def test_vot_catalog_warns(key_pop, message):
 
     warn_messages = [message]
     warnings = [UserWarning]
-    # The try/except can be removed once we require pyuvdata > 2.2.6
-    try:
-        with uvtest.check_warnings(warnings, match=warn_messages):
-            vot_catalog2 = pyuvsim.simsetup.initialize_catalog_from_params(
-                param_dict, return_recarray=False, return_catname=False
-            )
-    except AssertionError:
-        warn_messages += ["distutils Version classes are deprecated."] * 8
-        warnings += [DeprecationWarning] * 8
-        with uvtest.check_warnings(warnings, match=warn_messages):
-            vot_catalog2 = pyuvsim.simsetup.initialize_catalog_from_params(
-                param_dict, return_recarray=False, return_catname=False
-            )
+    with uvtest.check_warnings(warnings, match=warn_messages):
+        vot_catalog2 = pyuvsim.simsetup.initialize_catalog_from_params(
+            param_dict, return_recarray=False, return_catname=False
+        )
 
     assert vot_catalog == vot_catalog2
 

--- a/pyuvsim/tests/test_utils.py
+++ b/pyuvsim/tests/test_utils.py
@@ -6,9 +6,7 @@ import os
 
 import numpy as np
 import pytest
-import pyuvdata
 import pyuvdata.tests as uvtest
-from packaging import version  # packaging is installed with setuptools
 from pyuvdata import UVData
 
 from pyuvsim import utils as simutils
@@ -166,12 +164,6 @@ def test_write_uvdata_clobber(save_format, tmpdir):
     uv2 = UVData()
     uv2.read(expected_ofname)
 
-    # Depending on pyuvdata version the filename may exist
-    # munge the filename attribute
-    # This can be removed if we ever require pyuvdata>=2.2.1
-    if hasattr(uv2, "filename"):
-        uv2.filename = uv.filename
-
     if save_format == "ms":
         # MS adds some stuff to history & extra keywords
         uv2.history = uv.history
@@ -240,11 +232,10 @@ def test_write_fix_autos(tmpdir):
     ofname = str(tmpdir.join('test_file'))
     filing_dict = {'outfile_name': ofname}
 
-    if version.parse(pyuvdata.__version__) >= version.parse("2.2.7"):
-        with uvtest.check_warnings(
-            UserWarning, match="Fixing auto-correlations to be be real-only"
-        ):
-            simutils.write_uvdata(uv, filing_dict, return_filename=True, out_format='uvh5')
+    with uvtest.check_warnings(
+        UserWarning, match="Fixing auto-correlations to be be real-only"
+    ):
+        simutils.write_uvdata(uv, filing_dict, return_filename=True, out_format='uvh5')
 
 
 @pytest.mark.filterwarnings("ignore:LST values stored in this file are not self-consistent")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Strip out handling in tests for pyuvdata versions older than 2.2.8 (which we now require)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Other

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Other checklist:
- [x] All new and existing tests pass.
