### PR TITLE
Remove the pending deprecation warning for achromatic gaussian beams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changed
+- Removed deprecation of gaussian beams defined from sigma parameter.
 - Add tracking of the beam `freq_interp_kind` to the BeamList object since
 it is moving from a UVBeam attribute to a parameter to the `UVBeam.interp` method
 in future pyuvdata versions. Also ensure compatibility with current and future

--- a/pyuvsim/analyticbeam.py
+++ b/pyuvsim/analyticbeam.py
@@ -95,11 +95,6 @@ class AnalyticBeam:
             raise ValueError('type not recognized')
 
         self.sigma = sigma
-        if self.type == 'gaussian' and self.sigma is not None:
-            warnings.warn("Achromatic gaussian beams will not be supported in the future. "
-                          + "Define your gaussian beam by a dish diameter from now on.",
-                          PendingDeprecationWarning)
-
         if (spectral_index != 0.0) and (ref_freq is None):
             raise ValueError("ref_freq must be set for nonzero gaussian beam spectral index")
         elif ref_freq is None:

--- a/pyuvsim/tests/test_antenna.py
+++ b/pyuvsim/tests/test_antenna.py
@@ -18,7 +18,9 @@ def test_jones_set_spline(cst_beam, hera_loc):
     # Run get_beam_jones with spline options.
     array_location = hera_loc
     beam0 = cst_beam.copy()
-    beam0.freq_interp_kind = 'cubic'
+    if hasattr(beam0, "_freq_interp_kind"):
+        # this can go away when we require pyuvdata version >= 2.4.2
+        beam0.freq_interp_kind = "cubic"
     telescope_config_name = os.path.join(SIM_DATA_PATH, 'mwa128_config.yaml')
     with open(telescope_config_name, 'r') as yf:
         telconfig = yaml.safe_load(yf)

--- a/pyuvsim/tests/test_run.py
+++ b/pyuvsim/tests/test_run.py
@@ -179,7 +179,8 @@ def test_analytic_diffuse(model, tmpdir):
 @pytest.mark.filterwarnings("ignore:Fixing auto polarization power beams")
 def test_powerbeam_sim(cst_beam):
     new_cst = copy.deepcopy(cst_beam)
-    new_cst.freq_interp_kind = 'nearest'  # otherwise we get an error about freq interpolation
+    if hasattr(new_cst, "_freq_interp_kind"):
+        new_cst.freq_interp_kind = 'nearest'  # otherwise we get an error about freq interpolation
     new_cst.efield_to_power()
     beams = BeamList([new_cst] * 4)
     cfg = os.path.join(SIM_DATA_PATH, 'test_config', 'param_1time_1src_testcat.yaml')

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -440,18 +440,12 @@ def test_param_reader():
         [
             DeprecationWarning,
             UserWarning,
-            PendingDeprecationWarning,
-            PendingDeprecationWarning
         ],
         match=[
             "The return_beams parameter currently defaults to True, but starting in"
             "version 1.4 it will default to False.",
             "Cannot check consistency of a string-mode BeamList! Set force=True to "
             "force consistency checking.",
-            "chromatic gaussian beams will not be supported in the future. Define your "
-            "gaussian beam by a dish diameter from now on.",
-            "chromatic gaussian beams will not be supported in the future. Define your "
-            "gaussian beam by a dish diameter from now on.",
         ]
     ):
         uv_obj, new_beam_list, new_beam_dict = pyuvsim.initialize_uvdata_from_params(

--- a/pyuvsim/tests/test_telescope.py
+++ b/pyuvsim/tests/test_telescope.py
@@ -101,8 +101,9 @@ def test_convert_loop(beam_objs):
     assert beamlist._str_beam_list == []
 
     # Reset UVBeams
-    beams[0].freq_interp_kind = None
-    beams[1].freq_interp_kind = None
+    if hasattr(beams[0], "_freq_interp_kind"):
+        beams[0].freq_interp_kind = None
+        beams[1].freq_interp_kind = None
 
 
 def test_object_mode(beam_objs):

--- a/pyuvsim/tests/test_telescope.py
+++ b/pyuvsim/tests/test_telescope.py
@@ -42,19 +42,14 @@ def beam_objs_main():
     beams.append(pyuvsim.AnalyticBeam('airy', diameter=diameter_m))
     sigma = 0.03
     # Ignore warnings of pending sigma deprecation
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore", "Achromatic gaussian beams will not be supported in the future"
-        )
-        beams.append(pyuvsim.AnalyticBeam('gaussian', sigma=sigma))
-        ref_freq, alpha = 100e6, -0.5
-        beams.append(
-            pyuvsim.AnalyticBeam('gaussian', sigma=sigma, ref_freq=ref_freq, spectral_index=alpha)
-        )
+    beams.append(pyuvsim.AnalyticBeam('gaussian', sigma=sigma))
+    ref_freq, alpha = 100e6, -0.5
+    beams.append(
+        pyuvsim.AnalyticBeam('gaussian', sigma=sigma, ref_freq=ref_freq, spectral_index=alpha)
+    )
     return beams
 
 
-@pytest.mark.filterwarnings('ignore:Achromatic gaussian')
 @pytest.fixture()
 def beam_objs(beam_objs_main):
     beams_copy = copy.deepcopy(beam_objs_main)
@@ -62,7 +57,6 @@ def beam_objs(beam_objs_main):
     return beams_copy
 
 
-@pytest.mark.filterwarnings('ignore:Achromatic gaussian')
 def test_convert_loop(beam_objs):
     beams = beam_objs
 
@@ -111,7 +105,6 @@ def test_convert_loop(beam_objs):
     beams[1].freq_interp_kind = None
 
 
-@pytest.mark.filterwarnings('ignore:Achromatic gaussian')
 def test_object_mode(beam_objs):
     beams = beam_objs
     beamlist = pyuvsim.BeamList(beams)
@@ -150,7 +143,6 @@ def test_object_mode(beam_objs):
     assert beamlist[-1].sigma == 3.0
 
 
-@pytest.mark.filterwarnings('ignore:Achromatic gaussian')
 def test_string_mode(beam_objs):
     beams = beam_objs
     beamlist = pyuvsim.BeamList(beams)
@@ -178,7 +170,6 @@ def test_string_mode(beam_objs):
         pytest.fail("something went wrong with scraping uvb params")
 
 
-@pytest.mark.filterwarnings('ignore:Achromatic gaussian')
 @pytest.mark.filterwarnings("ignore:Cannot check consistency of a string-mode BeamList")
 def test_comparison(beam_objs):
     beamlist = pyuvsim.BeamList(beam_objs)
@@ -213,7 +204,6 @@ def test_no_overwrite(beam_objs):
     assert beamlist.uvb_params['freq_interp_kind'] == 'cubic'
 
 
-@pytest.mark.filterwarnings('ignore:Achromatic gaussian')
 def test_beamlist_errors(beam_objs):
     # make a copy to enable Telescope equality checking
     beams = copy.deepcopy(beam_objs)
@@ -298,7 +288,6 @@ def test_beam_basis_type(beam_objs):
 
 
 @pytest.mark.filterwarnings("ignore:key beam_path in extra_keywords is longer")
-@pytest.mark.filterwarnings('ignore:Achromatic gaussian')
 def test_beam_basis_type_errors(beam_objs):
     beam_objs[0].pixel_coordinate_system = "orthoslant_zenith"
     beam_objs[0].check()
@@ -359,7 +348,6 @@ def test_powerbeam_consistency(beam_objs):
     beamlist.check_consistency()
 
 
-@pytest.mark.filterwarnings('ignore:Achromatic gaussian')
 @pytest.mark.filterwarnings("ignore:key beam_path in extra_keywords is longer than 8")
 def test_check_azza_full_sky(beam_objs):
     beam = beam_objs

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -48,7 +48,11 @@ def multi_beams():
         beam0.read_beamfits(herabeam_default)
     beam0.use_future_array_shapes()
     beam0.extra_keywords['beam_path'] = herabeam_default
-    beam0.freq_interp_kind = 'cubic'
+
+    if hasattr(beam0, "_freq_interp_kind"):
+        # this can go away when we require pyuvdata version >= 2.4.2
+        beam0.freq_interp_kind = "cubic"
+
     if hasattr(beam0, "_interpolation_function"):
         beam0.interpolation_function = 'az_za_simple'
     beam1 = pyuvsim.AnalyticBeam('uniform')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove the deprecation warning on using sigma to define gaussian beams. Analytic beams will move to pyuvdata soon and will retain this functionality, so no deprecation is needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [x] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)
