### PR TITLE
Default to writing out UVH5 files rather than UVFITS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Added support for all UVBeam readable files rather than just beamfits.
 
 ### Changed
+- Changed the default file type for writing out UVData files to be the uvh5
+format rather than the uvfits format because it does not require phasing.
 - Removed deprecation of gaussian beams defined from sigma parameter.
 - Add tracking of the beam `freq_interp_kind` to the BeamList object since
 it is moving from a UVBeam attribute to a parameter to the `UVBeam.interp` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ it is moving from a UVBeam attribute to a parameter to the `UVBeam.interp` metho
 in future pyuvdata versions. Also ensure compatibility with current and future
 pyuvdata versions.
 
+### Deprecated
+- Specifying beams in yaml files as simple strings (they must now parse as a dict)
+and specifying global beam shape options like diameter and sigma (they must now
+be specified per beam.)
+
 ## [1.2.6] - 2022-07-17
 
 ### Changed

--- a/docs/parameter_files.rst
+++ b/docs/parameter_files.rst
@@ -25,7 +25,7 @@ these are passed into a simulation.
       outfile_prefix: 'sim' # Prefix for the output file name, separated by underscores
       outfile_suffix: 'results' # Suffix for output file name
       outfile_name: 'sim_results' # Alternatively, give the full name
-      output_format: 'uvfits'  # Format for output. Default is 'uvfits', but measurement sets ('ms'), 'miriad' and 'uvh5' are also supported.
+      output_format: 'uvfits'  # Format for output. Default is 'uvh5', but measurement sets ('ms'), 'miriad' and 'uvh5' are also supported.
       clobber: False        # overwrite existing files. (Default False)
     freq:
       Nfreqs: 10    # Number of frequencies

--- a/docs/parameter_files.rst
+++ b/docs/parameter_files.rst
@@ -25,7 +25,7 @@ these are passed into a simulation.
       outfile_prefix: 'sim' # Prefix for the output file name, separated by underscores
       outfile_suffix: 'results' # Suffix for output file name
       outfile_name: 'sim_results' # Alternatively, give the full name
-      output_format: 'uvfits'  # Format for output. Default is 'uvh5', but measurement sets ('ms'), 'miriad' and 'uvh5' are also supported.
+      output_format: 'uvfits'  # Format for output. Default is 'uvh5', but 'uvfits', measurement sets ('ms'), and 'miriad' are also supported.
       clobber: False        # overwrite existing files. (Default False)
     freq:
       Nfreqs: 10    # Number of frequencies

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -8,7 +8,7 @@ catalog and effectively "fills" the UVData object with simulated data.
 The function ``uvsim.run_pyuvsim`` in uvsim.py accepts as input a path to a yaml
 ``obsparam`` file and writes out the data to ``uvfits``, ``miriad``, or ``uvh5`` format.
 Optionally, it can also skip writing the data out and just return a ``UVData`` object
-filled with simulated data. The default behavior is to write to ``uvfits``.
+filled with simulated data. The default behavior is to write to ``uvh5``.
 
 This is demonstrated in more detail in ``run_param_pyuvsim.py`` in the scripts directory.
 See :doc:`parameter_files` for information on the parameter files.
@@ -46,11 +46,11 @@ return data for (it will only profile one MPI rank at a time!).
 Generating Config Files from Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The scripts ``uvfits_to_telescope_config.py`` and ``uvfits_to_config.py`` are provided
-for convenience. These will accept the path to any valid uvfits file as input, along
-with output file name options, and will generate telescope layout, telescope
-configuration, and an obsparam file for a simulation with the same time, frequency,
-and baseline structure as the data file.
+The scripts ``uvdata_to_telescope_config.py`` and ``uvdata_to_config.py`` are provided
+for convenience. These will accept the path to any valid file readable by UVData
+as input, along with output file name options, and will generate telescope layout,
+telescope configuration, and an obsparam file for a simulation with the same time,
+frequency, and baseline structure as the data file.
 
 Note that the generated configuration files will still need to be given paths to
 beam models and source catalogs before they can be used.

--- a/pyuvsim/simsetup.py
+++ b/pyuvsim/simsetup.py
@@ -2217,7 +2217,7 @@ def uvdata_to_telescope_config(
 def uvdata_to_config_file(uvdata_in, param_filename=None, telescope_config_name='',
                           layout_csv_name='', catalog='mock', path_out='.'):
     """
-    Extract simulation configuration settings from uvfits.
+    Extract simulation configuration settings from a UVData object.
 
     When used with :func:`~uvdata_to_telescope_config`, this will produce all the necessary
     configuration yaml and csv file to make an "empty" :class:`pyuvdata.UVData` object comparable to

--- a/pyuvsim/tests/test_simsetup.py
+++ b/pyuvsim/tests/test_simsetup.py
@@ -459,10 +459,15 @@ def test_param_reader():
 
     with open(param_filename, 'r') as fhandle:
         param_dict = yaml.safe_load(fhandle)
-    expected_ofilepath = pyuvsim.utils.write_uvdata(
-        uv_obj, param_dict, return_filename=True, dryrun=True
-    )
-    assert './sim_results.uvfits' == expected_ofilepath
+    with uvtest.check_warnings(
+        UserWarning,
+        match="No out format specified for uvdata file. Defaulting to uvh5 "
+        "(note this is a defaulting change, it used to default to uvfits)."
+    ):
+        expected_ofilepath = pyuvsim.utils.write_uvdata(
+            uv_obj, param_dict, return_filename=True, dryrun=True
+        )
+    assert './sim_results.uvh5' == expected_ofilepath
 
     # Spoof attributes that won't match.
     uv_obj.antenna_names = uv_obj.antenna_names.tolist()

--- a/scripts/uvdata_to_config.py
+++ b/scripts/uvdata_to_config.py
@@ -8,9 +8,14 @@ from pyuvdata import UVData
 
 import pyuvsim.simsetup
 
-# Take a uvfits file, and save sim parameters as a yaml file.
+# Take a uvdata readable file, and save sim parameters as a yaml file.
 
-parser = argparse.ArgumentParser(description=("Generate basic simulation parameters from uvfits."))
+parser = argparse.ArgumentParser(
+    description=(
+        "Generate basic simulation parameters from a data file readable by "
+        ":class:`pyuvdata.UVData`."
+    )
+)
 
 parser.add_argument('file_in', metavar='<FILE>', type=str, nargs='+')
 parser.add_argument('-p', '--param_filename', default=None)

--- a/scripts/uvdata_to_telescope_config.py
+++ b/scripts/uvdata_to_telescope_config.py
@@ -11,10 +11,15 @@ from pyuvdata import UVData
 import pyuvsim.simsetup
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 
-# Read in a uvfits file and automatically generate yaml files.
+# Read in a uvdata readable file and automatically generate yaml files.
 # Will assume the same beam_id for all antennas for now.
 
-parser = argparse.ArgumentParser(description=("Extracts antenna position info from uvfits."))
+parser = argparse.ArgumentParser(
+    description=(
+        "Extracts antenna position info from a data file readable by "
+        ":class:`pyuvdata.UVData`."
+    )
+)
 
 parser.add_argument('file_in', metavar='<FILE>', type=str, nargs='+')
 parser.add_argument('-l', '--layout_csv_name', default=None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the default output format to UVH5 rather than UVFITS, mostly because it doesn't require phasing. All formats are available, this just changes the default if nothing is set.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #376

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Breaking change checklist:
- [x] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the documentation to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [ ] I have checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/master/CHANGELOG.md).
