### PR TITLE
Move mpi fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added support for all UVBeam readable files rather than just beamfits.
 
 ### Changed
+- Moved all necessary mpi broadcasts calls into `run_uvdata_uvsim` to make it more user friendly.
 - Changed the default file type for writing out UVData files to be the uvh5
 format rather than the uvfits format because it does not require phasing.
 - Removed deprecation of gaussian beams defined from sigma parameter.

--- a/pyuvsim/tests/test_run.py
+++ b/pyuvsim/tests/test_run.py
@@ -206,9 +206,10 @@ def test_powerbeam_sim(cst_beam):
         cfg, return_catname=False
     )
     sky_model = pyuvsim.simsetup.SkyModelData(sky_model)
+    beam_dict = {n: 0 for n in range(4)}
 
     with pytest.raises(ValueError, match="Beam type must be efield!"):
-        pyuvsim.run_uvdata_uvsim(input_uv, beams, catalog=sky_model)
+        pyuvsim.run_uvdata_uvsim(input_uv, beams, beam_dict, catalog=sky_model)
 
 
 @pytest.mark.filterwarnings("ignore:Cannot check consistency of a string-mode BeamList")
@@ -380,12 +381,12 @@ def test_pol_error():
     hera_uv.polarizations = ['xx']
 
     with pytest.raises(ValueError, match='input_uv must have XX,YY,XY,YX polarization'):
-        pyuvsim.run_uvdata_uvsim(hera_uv, ['beamlist'])
+        pyuvsim.run_uvdata_uvsim(hera_uv, ['beamlist'], {}, catalog=pyuvsim.SkyModelData())
 
 
 def test_input_uv_error():
     with pytest.raises(TypeError, match="input_uv must be UVData object"):
-        pyuvsim.run_uvdata_uvsim(None, None)
+        pyuvsim.run_uvdata_uvsim(None, None, {}, catalog=pyuvsim.SkyModelData())
 
 
 @pytest.mark.filterwarnings("ignore:Cannot check consistency of a string-mode BeamList")

--- a/pyuvsim/tests/test_uvsim.py
+++ b/pyuvsim/tests/test_uvsim.py
@@ -1077,7 +1077,7 @@ def test_run_mpierr():
             pyuvsim.run_uvsim(params, return_uv=True)
 
         with pytest.raises(ImportError, match='You need mpi4py to use the uvsim module'):
-            pyuvsim.run_uvdata_uvsim(UVData(), ['beamlist'])
+            pyuvsim.run_uvdata_uvsim(UVData(), ['beamlist'], {}, pyuvsim.SkyModelData())
 
 
 @pytest.mark.filterwarnings("ignore:Cannot check consistency of a string-mode BeamList")

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -651,8 +651,8 @@ def _set_nsky_parts(Nsrcs, cat_nfreqs, Nsky_parts):
 def run_uvdata_uvsim(
     input_uv,
     beam_list,
-    beam_dict=None,
-    catalog=None,
+    beam_dict,
+    catalog,
     beam_interp_check=None,
     quiet=False,
     block_nonroot_stdout=True,
@@ -711,9 +711,6 @@ def run_uvdata_uvsim(
     input_uv = comm.bcast(input_uv, root=0)
     beam_list = comm.bcast(beam_list, root=0)
     beam_dict = comm.bcast(beam_dict, root=0)
-
-    if catalog is None:
-        catalog = SkyModelData()
     catalog.share(root=0)
 
     if not isinstance(input_uv, UVData):

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -708,6 +708,11 @@ def run_uvdata_uvsim(
     comm = mpi.get_comm()
     Npus = mpi.get_Npus()
 
+    input_uv = comm.bcast(input_uv, root=0)
+    beam_list = comm.bcast(beam_list, root=0)
+    beam_dict = comm.bcast(beam_dict, root=0)
+    catalog.share(root=0)
+
     if not isinstance(input_uv, UVData):
         raise TypeError("input_uv must be UVData object")
 
@@ -954,11 +959,6 @@ def run_uvsim(
         skydata = simsetup.SkyModelData(skydata)
         if not quiet:
             print(f"Skymodel setup took {(Time.now() - start).to('minute'):.3f}")
-
-    input_uv = comm.bcast(input_uv, root=0)
-    beam_list = comm.bcast(beam_list, root=0)
-    beam_dict = comm.bcast(beam_dict, root=0)
-    skydata.share(root=0)
 
     start = Time.now()
     uv_out = run_uvdata_uvsim(

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -941,7 +941,6 @@ def run_uvsim(
 
     mpi.start_mpi(block_nonroot_stdout=block_nonroot_stdout)
     rank = mpi.get_rank()
-    comm = mpi.get_comm()
 
     input_uv = UVData()
     beam_list = None

--- a/pyuvsim/uvsim.py
+++ b/pyuvsim/uvsim.py
@@ -711,6 +711,9 @@ def run_uvdata_uvsim(
     input_uv = comm.bcast(input_uv, root=0)
     beam_list = comm.bcast(beam_list, root=0)
     beam_dict = comm.bcast(beam_dict, root=0)
+
+    if catalog is None:
+        catalog = SkyModelData()
     catalog.share(root=0)
 
     if not isinstance(input_uv, UVData):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
move essential mpi sharing functions into the lowest level code available.
This is an effort to make the code more user friendly especially if the user calls `run_uvdata_uvsim` directly.

## Description
<!--- Describe your changes in detail -->
Moves all broadcasting inside `run_uvdata_uvsim`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
closes #433 

