### PR TITLE
Support custom beam patterns in AnalyticBeam class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Added support for custom beam patterns to `AnalyticBeam`
+
 ## [1.3.0] - 2024-07-17
 
 ### Added

--- a/tests/test_analyticbeam.py
+++ b/tests/test_analyticbeam.py
@@ -57,6 +57,27 @@ def test_uniform_beam(heratext_posfreq):
     np.testing.assert_allclose(interpolated_beam, expected_data)
 
 
+def test_func_beam(heratext_posfreq):
+    def cos_squared(a,z,f):
+        return np.cos(z)**2
+    beam = pyuvsim.AnalyticBeam("func", func=cos_squared)
+
+    beam.peak_normalize()
+
+    az_vals, za_vals, freqs = heratext_posfreq
+
+    nsrcs = az_vals.size
+    n_freqs = freqs.size
+
+    interpolated_beam, _ = beam.interp(
+        az_array=az_vals, za_array=za_vals, freq_array=freqs
+    )
+    expected_data = np.zeros((2, 2, n_freqs, nsrcs), dtype=float)
+    expected_data[1, 0, :, :] = cos_squared(az_vals, za_vals, freqs)
+    expected_data[0, 1, :, :] = cos_squared(az_vals, za_vals, freqs)
+    np.testing.assert_allclose(interpolated_beam, expected_data)
+
+
 def test_airy_beam_values(heratext_posfreq):
     diameter_m = 14.0
     beam = pyuvsim.AnalyticBeam("airy", diameter=diameter_m)
@@ -300,6 +321,16 @@ def test_comparison():
     not_beam = UVData()
     assert beam1 != not_beam
     assert beam2 != beam1
+
+    def cos_squared(a,z,f):
+        return np.cos(z)**2
+    def sin_squared(a,z,f):
+        return np.sin(z)**2
+    beam1 = pyuvsim.AnalyticBeam("func", func=cos_squared)
+    beam2 = pyuvsim.AnalyticBeam("func", func=cos_squared)
+    beam3 = pyuvsim.AnalyticBeam("func", func=sin_squared)
+    assert beam1 == beam2
+    assert beam1 != beam3
 
 
 def test_beam_init_errs():


### PR DESCRIPTION
Extend `AnalyticBeam` class to support any function of alt, az and frequency

## Description

The `AnalyticBeam` class has been extended to support beam calculations using custom functions.

To use, the `type='func'` argument is set, and the new optional argument `func=my_custom_function` is set:

```python
def cos_squared(a, z, f):
    return np.cos(z)**2

beam = AnalyticBeam('func', func=cos_squared)
```

The function must have exactly three arguments, correspinding to  `az_array, za_array` and `freq_array`, as used in the interp class method:

```
    def interp(self, az_array, za_array, freq_array, **kwargs):
        """
        Evaluate the primary beam at given sky coordinates and frequencies.

        (mocks :meth:`pyuvdata.UVBeam.interp`, but these are analytic, so no interpolation is done.)

        Parameters
        ----------
        az_array : array-like of float
            Azimuth values to evaluate at in radians. Should be a 1D array with the same
            length as `za_array`. The azimuth here has the :class:`pyuvdata.UVBeam` convention:
            North of East (East=0, North=pi/2)
        za_array : array-like of float
            Zenith angle values to evaluate at in radians. Should be a 1D array with the
            same length as `az_array`.
        freq_array : array-like of float
            Frequency values to evaluate at in Hz. Should be a 1D array.
```

## Motivation and Context

The `AnalyticBeam` currently supports uniform, airy and Gaussian beam patterns. This PR allows any function of altitude, zenith angle, and frequency to be used, increasing flexibility.

My motivation was to add support for beams generated from simple combinations of Numpy ufuncs (e.g. cos, sin, exp) with corresponding analytical functions. However, as long as the function returns a value for any given alt/az/freq, it doesn't strictly need to be an analytical function. 

I chose this approach over adding another simple analytic function, e.g. `type='cos_squared'`, as it was far more flexible.

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.


New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the documentation to highlight my new feature (if appropriate).
- [x] I have added tests to cover my new feature.
- [x] All new tests pass
- [x] All existing tests pass
- [x] updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/main/CHANGELOG.md)

Things I haven't done:
- [ ] Checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged. _Not sure what this means_.
- [ ] checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR. _Have not done, but would be very surprised if it impacted runtimes_
- [ ] _I have no intention of running linters or fixing any linting issues_

Documentation change checklist:
- [x] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)
