### PR TITLE
Fix docs to specify correct set of catalog file types

### DIFF
--- a/docs/parameter_files.rst
+++ b/docs/parameter_files.rst
@@ -37,8 +37,8 @@ these are passed into a simulation.
           1.0064e+08, 1.0072e+08]
       bandwidth: 800000.0
     sources:
-      catalog: '../pyuvsim/data/gleam_50srcs.vot' # Path to catalog file (txt, vot, hdf5, etc.) readable with pyradiosky.
-      filetype : "gleam" # optionally specify the catalog filetype (skyh5, gleam, vot, text, hdf5). If not specified, the code attempt to guess the type.
+      catalog: '../pyuvsim/data/gleam_50srcs.vot' # Path to catalog file (txt, vot, skyh5, fhd, etc.) readable with pyradiosky.
+      filetype : "gleam" # optionally specify the catalog filetype (skyh5, gleam, vot, text, fhd). If not specified, the code attempt to guess the type.
       spectral_type: flat # If using the GLEAM catalog, specify the spectral type (flat, subband or spectral_index). Defaults to flat.
       table_name: single  # Required for non-GLEAM VO table files
       id_column: name  # Required for non-GLEAM VO table files
@@ -293,7 +293,7 @@ Sources
       * ``lat_column`` : The name of the column to use for the source latitudes (required, ``ra_column`` is a deprecated synonym).
       * ``frame`` : The name of the ``astropy`` frame to use.
 
-    Optionally specify the ``filetype`` as one of ['skyh5', 'gleam', 'vot', 'text', 'hdf5'].
+    Optionally specify the ``filetype`` as one of ['skyh5', 'gleam', 'vot', 'text', 'fhd'].
     If this is not specified, the code attempts to guess what file type it is.
 
     Alternatively, you can specify a ``mock`` and provide the ``mock_arrangement``

--- a/src/pyuvsim/simsetup.py
+++ b/src/pyuvsim/simsetup.py
@@ -880,7 +880,7 @@ def initialize_catalog_from_params(
     input_uv: :class:`pyuvdata.UVData`
         Used to set location for mock catalogs and for horizon cuts.
     filetype : str
-        One of ['skyh5', 'gleam', 'vot', 'text', 'hdf5'] or None.
+        One of ['skyh5', 'gleam', 'vot', 'text', 'fhd'] or None.
         If None, the code attempts to guess what the file type is.
     return_catname: bool
         Return the catalog name. Defaults to True currently but will default to False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the docs to correctly specify the allowed file types for sky model catalogs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [x] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Documentation change checklist:
- [x] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)
