### PR TITLE
Construct with bls not select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+- Setting the `select.bls` property in the obsparams file now selects baselines _before_
+creating the UVData object, rather than down-selecting afterwards, saving memory and time.
+
 ## [1.3.1] - 2024-07-18
 
 ### Added

--- a/src/pyuvsim/simsetup.py
+++ b/src/pyuvsim/simsetup.py
@@ -2037,12 +2037,12 @@ def initialize_uvdata_from_params(
     else:
         cat_name = param_dict["cat_name"]
     phase_center_catalog = {0: {"cat_name": cat_name, "cat_type": "unprojected"}}
-    
+
     # Set the antpairs _before_ creating the uvdata object to conserve memory.
-    antpairs = param_dict.get('select', {}).pop('bls', None)
+    antpairs = param_dict.get("select", {}).pop("bls", None)
     if isinstance(antpairs, str):
         antpairs = ast.literal_eval(antpairs)
-        
+
     # remove the pragma below after pyuvdata v3.0 is released
     if hasattr(UVData(), "telescope"):  # pragma: nocover
         tel_init_params = {"location": telescope_location}
@@ -2063,7 +2063,7 @@ def initialize_uvdata_from_params(
                 tel_init_params[tel_key] = tele_params[key]
         if "instrument" not in tel_init_params:
             tel_init_params["instrument"] = tel_init_params["name"]
-      
+
         uv_obj = UVData.new(
             telescope=Telescope.new(**tel_init_params),
             phase_center_catalog=phase_center_catalog,

--- a/src/pyuvsim/simsetup.py
+++ b/src/pyuvsim/simsetup.py
@@ -2037,7 +2037,12 @@ def initialize_uvdata_from_params(
     else:
         cat_name = param_dict["cat_name"]
     phase_center_catalog = {0: {"cat_name": cat_name, "cat_type": "unprojected"}}
-
+    
+    # Set the antpairs _before_ creating the uvdata object to conserve memory.
+    antpairs = param_dict.get('select', {}).pop('bls', None)
+    if isinstance(antpairs, str):
+        antpairs = ast.literal_eval(antpairs)
+        
     # remove the pragma below after pyuvdata v3.0 is released
     if hasattr(UVData(), "telescope"):  # pragma: nocover
         tel_init_params = {"location": telescope_location}
@@ -2058,7 +2063,7 @@ def initialize_uvdata_from_params(
                 tel_init_params[tel_key] = tele_params[key]
         if "instrument" not in tel_init_params:
             tel_init_params["instrument"] = tel_init_params["name"]
-
+      
         uv_obj = UVData.new(
             telescope=Telescope.new(**tel_init_params),
             phase_center_catalog=phase_center_catalog,
@@ -2066,6 +2071,7 @@ def initialize_uvdata_from_params(
             history="",
             do_blt_outer=True,
             time_axis_faster_than_bls=False,
+            antpairs=antpairs,
             **uvparam_dict,
         )
     else:
@@ -2086,6 +2092,7 @@ def initialize_uvdata_from_params(
             history="",
             do_blt_outer=True,
             time_axis_faster_than_bls=True,
+            antpairs=antpairs,
             **uvparam_dict,
         )
         uv_obj.telescope_location = np.asarray(uv_obj.telescope_location)

--- a/src/pyuvsim/simsetup.py
+++ b/src/pyuvsim/simsetup.py
@@ -1772,7 +1772,6 @@ def subselect(uv_obj, param_dict):
         "antenna_nums",
         "antenna_names",
         "ant_str",
-        "bls",
         "frequencies",
         "freq_chans",
         "times",
@@ -1785,12 +1784,6 @@ def subselect(uv_obj, param_dict):
     if "antenna_nums" in select_params:
         select_params["antenna_nums"] = list(map(int, select_params["antenna_nums"]))
     redundant_threshold = param_dict["select"].get("redundant_threshold", None)
-    if "bls" in select_params:
-        bls = select_params["bls"]
-        if isinstance(bls, str):
-            # If read from file, this should be a string.
-            bls = ast.literal_eval(bls)
-            select_params["bls"] = bls
     if len(select_params) > 0:
         uv_obj.select(**select_params)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change the behaviour of `initialize_uvdata_from_params` so that if the user sets `select.bls` in the YAML, the selection is done prior to creating the UVData object (i.e. before doing the outer product with times, and initializing the data arrays), instead of down-selecting afterwards.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This saves some memory, especially if the downselect is large.

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Performance enhancement

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

