### PR TITLE
perf: allow not running checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Major restructuring of the BeamList object to use shared memory and remove the
 string/object mode switch.
 - BeamLists now contain pyuvdata BeamInterface objects
-- Updated minimum dependency versions: pyuvdata>=3.1.0
+- Updated minimum dependency versions: pyuvdata>=3.1.2
 - Updated minimum optional dependency versions: lunarsky>=0.2.5
 - Setting the `select.bls` property in the obsparams file now selects baselines _before_
 creating the UVData object, rather than down-selecting afterwards, saving memory and time.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Required:
 * psutil
 * pyradiosky>=1.0.1
 * python>=3.10
-* pyuvdata>=3.1.0
+* pyuvdata>=3.1.2
 * pyyaml>=5.4.1
 * scipy>=1.8
 * setuptools_scm>=8.1

--- a/ci/min_versions.yaml
+++ b/ci/min_versions.yaml
@@ -14,7 +14,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pytest-xdist
-  - pyuvdata==3.1.1  # 3.1.0 is not available on conda
+  - pyuvdata==3.1.2
   - pyyaml==5.4.1
   - scipy==1.8.*
   - setuptools_scm==8.1

--- a/ci/publish.yaml
+++ b/ci/publish.yaml
@@ -5,7 +5,7 @@ dependencies:
   - astropy>=6.0
   - numpy>=1.23
   - pip
-  - pyuvdata>=3.1.0
+  - pyuvdata>=3.1.2
   - pyyaml>=5.4.1
   - scipy>=1.8
   - setuptools_scm>=8.1

--- a/ci/pyuvsim_tests_mpich.yaml
+++ b/ci/pyuvsim_tests_mpich.yaml
@@ -15,7 +15,7 @@ dependencies:
   - pytest
   - pytest-cov>=5.0
   - pytest-xdist
-  - pyuvdata>=3.1.0
+  - pyuvdata>=3.1.2
   - pyyaml>=5.4.1
   - scipy>=1.8
   - setuptools_scm>=8.1

--- a/ci/pyuvsim_tests_openmpi.yaml
+++ b/ci/pyuvsim_tests_openmpi.yaml
@@ -15,7 +15,7 @@ dependencies:
   - pytest
   - pytest-cov>=5.0
   - pytest-xdist
-  - pyuvdata>=3.1.0
+  - pyuvdata>=3.1.2
   - pyyaml>=5.4.1
   - scipy>=1.8
   - setuptools_scm>=8.1

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - pytest
   - pytest-cov>=5.0.0
   - pytest-xdist
-  - pyuvdata>=3.1.0
+  - pyuvdata>=3.1.2
   - pyyaml>=5.4.1
   - scipy>=1.8
   - setuptools_scm>=8.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "numpy>=1.23",
     "psutil",
     "pyradiosky>=1.0.1",
-    "pyuvdata>=3.1.0",
+    "pyuvdata>=3.1.2",
     "pyyaml>=5.4.1",
     "scipy>=1.8",
     "setuptools>=64",

--- a/src/pyuvsim/simsetup.py
+++ b/src/pyuvsim/simsetup.py
@@ -2407,10 +2407,7 @@ def initialize_uvdata_from_keywords(
     param_dict["obs_param_file"] = os.path.basename(output_yaml_filename)
     param_dict["telescope"].update(layout_params)
     uv_obj = initialize_uvdata_from_params(
-        param_dict,
-        return_beams=False,
-        force_beam_check=force_beam_check,
-        check_kw=check_kw,
+        param_dict, return_beams=False, check_kw=check_kw
     )
 
     if complete:

--- a/src/pyuvsim/simsetup.py
+++ b/src/pyuvsim/simsetup.py
@@ -2186,6 +2186,8 @@ def initialize_uvdata_from_keywords(
     write_files=True,
     path_out=None,
     complete=False,
+    force_beam_check=False,
+    check_kw: dict | None = None,
     **kwargs,
 ):
     """
@@ -2404,10 +2406,15 @@ def initialize_uvdata_from_keywords(
 
     param_dict["obs_param_file"] = os.path.basename(output_yaml_filename)
     param_dict["telescope"].update(layout_params)
-    uv_obj = initialize_uvdata_from_params(param_dict, return_beams=False)
+    uv_obj = initialize_uvdata_from_params(
+        param_dict,
+        return_beams=False,
+        force_beam_check=force_beam_check,
+        check_kw=check_kw,
+    )
 
     if complete:
-        _complete_uvdata(uv_obj, inplace=True)
+        _complete_uvdata(uv_obj, inplace=True, check_kw=False)
 
     return uv_obj
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since `UVData.new()` already runs an object check, we pass the `check_kw` to it instead of running the object check in `_complete_data`. The object check actually takes a somewhat significant amount of time (because it has to recompute all the LSTs to check them...) so it's good to give the user control over when it should be run, and remove duplication.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
HERA validation sims.

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Performance enhancement
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.
