### PR TITLE
added space and period to beam specification error message

### DIFF
--- a/src/pyuvsim/simsetup.py
+++ b/src/pyuvsim/simsetup.py
@@ -1130,8 +1130,8 @@ def _construct_beam_list(
 
         if not isinstance(beam_model, dict | AnalyticBeam | UVBeam):
             raise ValueError(
-                "Beam model is not properly specified in telescope config file."
-                f"It is specified as {beam_model}"
+                "Beam model is not properly specified in telescope config file. "
+                f"It is specified as {beam_model}."
             )
 
         if not isinstance(beam_model, AnalyticBeam | UVBeam) and not (


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
A space and period have been added to the beam specification error message.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Minor message format fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.
