### PR TITLE
Handing change in `extra_keywords` warning in pyuvdata

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -1,6 +1,10 @@
 name: Publish Python distributions to PyPI and TestPyPI
 
-on: push
+on:
+  release:
+    types: [published]
+  pull_request:
+    branch: main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/tests/test_uvsim.py
+++ b/tests/test_uvsim.py
@@ -67,6 +67,13 @@ def multi_beams():
         ):
             beam5.to_healpix(nside=8)
         beams.append(beam5)
+    except AssertionError:
+        # If we have an assert error, that means that import worked, but the warning
+        # was not raised due to the change in UVBeam warning behavior. Try again...
+        # TODO: Simplify this once pyuvdata v3.2 is required
+        with check_warnings(None):
+            beam5.to_healpix(nside=8)
+        beams.append(beam5)
     except ImportError:
         pass
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates tests to account for changing behavior in UVBeam warnings.

## Description
<!--- Describe your changes in detail -->
The multi_beam constructor in `test_uvsim` has been updated to account for an upcoming change in behavior, where the length o extra_keywords is no longer generating a warning prior to file wrtiing.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This change is being made to due to a PR on pyuvdata (https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/1523), which will cause an error in the future. There is no functional change in behavior here, just an update to testing/CI processes. 


## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.


Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [x] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
