### PR TITLE
More fixes to be compatible with new telescope attributes in pyuvdata

### DIFF
--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -40,7 +40,6 @@ def goto_tempdir(tmpdir):
     os.chdir(cwd)
 
 
-@pytest.mark.filterwarnings("ignore:antenna_diameters are not set")
 @pytest.mark.filterwarnings("ignore:Fixing auto-correlations to be be real-only")
 @pytest.mark.parametrize(
     "paramfile", ["param_1time_1src_testcat.yaml", "param_1time_1src_testvot.yaml"]

--- a/tests/test_simsetup.py
+++ b/tests/test_simsetup.py
@@ -1915,6 +1915,10 @@ def test_beamlist_init(rename_beamfits, pass_beam_type, tmp_path):
         beam_file = beamfits_file
         telconfig["beam_paths"][0] = {"filename": beam_file, "file_type": "beamfits"}
 
+    # always do this once we require pyuvdata >= 3.2
+    if hasattr(Telescope(), "mount_type"):
+        telconfig["beam_paths"][0]["mount_type"] = "fixed"
+
     telconfig["beam_paths"][6]["filename"] = os.path.join(
         UV_DATA_PATH, "mwa_full_EE_test.h5"
     )
@@ -1929,10 +1933,6 @@ def test_beamlist_init(rename_beamfits, pass_beam_type, tmp_path):
         "analytic beam without the AnalyticBeam constructors will cause an "
         "error in version 1.6"
     ] * entries_warnings
-
-    # always do this once we require pyuvdata >= 3.2
-    if hasattr(Telescope(), "mount_type"):
-        warn_list.append("The mount_type parameter must be set for UVBeam objects")
 
     warn_types = DeprecationWarning
 

--- a/tests/test_simsetup.py
+++ b/tests/test_simsetup.py
@@ -569,15 +569,17 @@ def test_param_reader(telparam_in_obsparam, tmpdir):
 
     beam_dict = {"ANT1": 0, "ANT2": 1, "ANT3": 2, "ANT4": 3}
 
+    warn_list = [
+        "The reorder_blt_kw parameter is deprecated in favor of setting "
+        "obs_param['ordering']['blt_order']. This will become an error in "
+        "version 1.5"
+    ]
+    # always do this once we require pyuvdata >= 3.2
+    if not telparam_in_obsparam and hasattr(Telescope, "mount_type"):
+        warn_list.append("The mount_type parameter must be set for UVBeam objects")
+
     # Check default configuration
-    with check_warnings(
-        [DeprecationWarning],
-        match=[
-            "The reorder_blt_kw parameter is deprecated in favor of setting "
-            "obs_param['ordering']['blt_order']. This will become an error in "
-            "version 1.5"
-        ],
-    ):
+    with check_warnings(DeprecationWarning, match=warn_list):
         uv_obj, new_beam_list, new_beam_dict = simsetup.initialize_uvdata_from_params(
             new_param_file,
             reorder_blt_kw={"order": "time", "minor_order": "baseline"},
@@ -1923,6 +1925,11 @@ def test_beamlist_init(rename_beamfits, pass_beam_type, tmp_path):
         "analytic beam without the AnalyticBeam constructors will cause an "
         "error in version 1.6"
     ] * entries_warnings
+
+    # always do this once we require pyuvdata >= 3.2
+    if hasattr(Telescope, "mount_type"):
+        warn_list.append("The mount_type parameter must be set for UVBeam objects")
+
     warn_types = DeprecationWarning
 
     Nfreqs = 10
@@ -1972,17 +1979,19 @@ def test_beamlist_init_freqrange(sel_type):
         telconfig["select"] = {"freq_buffer": 0}
         freq_range_pass = None
 
-    with check_warnings(
-        DeprecationWarning,
-        match=[
-            "Entries in 'beam_paths' should be specified using either the UVBeam "
-            "or AnalyticBeam constructors or using a dict syntax for UVBeams. "
-            "For examples see the parameter_files documentation. Specifying "
-            "analytic beam without the AnalyticBeam constructors will cause an "
-            "error in version 1.6"
-        ]
-        * 5,
-    ):
+    warn_list = [
+        "Entries in 'beam_paths' should be specified using either the UVBeam "
+        "or AnalyticBeam constructors or using a dict syntax for UVBeams. "
+        "For examples see the parameter_files documentation. Specifying "
+        "analytic beam without the AnalyticBeam constructors will cause an "
+        "error in version 1.6"
+    ] * 5
+
+    # always do this once we require pyuvdata >= 3.2
+    if hasattr(Telescope, "mount_type"):
+        warn_list.append("The mount_type parameter must be set for UVBeam objects")
+
+    with check_warnings(DeprecationWarning, match=warn_list):
         beam_list = simsetup._construct_beam_list(
             np.arange(6), telconfig, freq_range=freq_range_pass, freq_array=freqs
         )
@@ -2201,14 +2210,17 @@ def test_skymodeldata_attr_bases(inds, cat_with_some_pols):
 def test_simsetup_with_obsparam_freq_buffer():
     fl = os.path.join(SIM_DATA_PATH, "test_config", "obsparam_diffuse_sky_freqbuf.yaml")
 
-    with check_warnings(
-        [DeprecationWarning],
-        match=[
-            "Beam selections should be specified in the telescope "
-            "configuration, not in the obsparam. This will become an error in "
-            "version 1.5"
-        ],
-    ):
+    warn_list = [
+        "Beam selections should be specified in the telescope "
+        "configuration, not in the obsparam. This will become an error in "
+        "version 1.5"
+    ]
+
+    # always do this once we require pyuvdata >= 3.2
+    if hasattr(Telescope, "mount_type"):
+        warn_list.append("The mount_type parameter must be set for UVBeam objects")
+
+    with check_warnings(DeprecationWarning, match=warn_list):
         _, beams, _ = simsetup.initialize_uvdata_from_params(fl, return_beams=True)
 
     assert beams[0].beam.freq_array.max() < 101e6

--- a/tests/test_simsetup.py
+++ b/tests/test_simsetup.py
@@ -43,6 +43,10 @@ from . import compare_dictionaries
 
 herabeam_default = os.path.join(SIM_DATA_PATH, "HERA_NicCST.beamfits")
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:antenna_diameters are not set or are being overwritten."
+)
+
 # Five different test configs
 param_filenames = [
     os.path.join(SIM_DATA_PATH, "test_config", f"param_10time_10chan_{x}.yaml")
@@ -575,7 +579,7 @@ def test_param_reader(telparam_in_obsparam, tmpdir):
         "version 1.5"
     ]
     # always do this once we require pyuvdata >= 3.2
-    if not telparam_in_obsparam and hasattr(Telescope, "mount_type"):
+    if not telparam_in_obsparam and hasattr(Telescope(), "mount_type"):
         warn_list.append("The mount_type parameter must be set for UVBeam objects")
 
     # Check default configuration
@@ -1629,7 +1633,7 @@ def test_keyword_param_loop(tmpdir):
     antpos_d = dict(zip(antnums, antpos_enu, strict=False))
 
     tel_feed_kwargs = {}
-    if hasattr(Telescope, "feed_array"):
+    if hasattr(Telescope(), "feed_array"):
         # always do this once we require pyuvdata >= 3.2
         tel_feed_kwargs = {
             "feed_array": ["x", "y"],
@@ -1927,7 +1931,7 @@ def test_beamlist_init(rename_beamfits, pass_beam_type, tmp_path):
     ] * entries_warnings
 
     # always do this once we require pyuvdata >= 3.2
-    if hasattr(Telescope, "mount_type"):
+    if hasattr(Telescope(), "mount_type"):
         warn_list.append("The mount_type parameter must be set for UVBeam objects")
 
     warn_types = DeprecationWarning
@@ -1988,7 +1992,7 @@ def test_beamlist_init_freqrange(sel_type):
     ] * 5
 
     # always do this once we require pyuvdata >= 3.2
-    if hasattr(Telescope, "mount_type"):
+    if hasattr(Telescope(), "mount_type"):
         warn_list.append("The mount_type parameter must be set for UVBeam objects")
 
     with check_warnings(DeprecationWarning, match=warn_list):
@@ -2217,7 +2221,7 @@ def test_simsetup_with_obsparam_freq_buffer():
     ]
 
     # always do this once we require pyuvdata >= 3.2
-    if hasattr(Telescope, "mount_type"):
+    if hasattr(Telescope(), "mount_type"):
         warn_list.append("The mount_type parameter must be set for UVBeam objects")
 
     with check_warnings(DeprecationWarning, match=warn_list):

--- a/tests/test_uvsim.py
+++ b/tests/test_uvsim.py
@@ -43,7 +43,11 @@ herabeam_default = os.path.join(SIM_DATA_PATH, "HERA_NicCST.beamfits")
 
 def multi_beams():
     beam0 = UVBeam()
-    beam0.read_beamfits(herabeam_default)
+    # always do this once we require pyuvdata >= 3.2
+    if hasattr(UVData().telescope, "mount_type"):
+        beam0.read(herabeam_default, mount_type="fixed")
+    else:
+        beam0.read(herabeam_default)
     beam0.extra_keywords["beam_path"] = herabeam_default
     beam0.peak_normalize()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Continuation of #533

## Description
<!--- Describe your changes in detail -->
Modifies some tests to handle some new warningis from `pyuvdata.Telescope` related to handling of a new paramter `mount_type`, wihich describes the optics of a given antenna.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes four tests (all within `test_simsetup` which are going to break with an upcoming PR of pyuvdata due to a change in warning message behavior. No further changes to the underlying objects within `pyuvsim` has been made.

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
