### PR TITLE
Updated conftest and test_run_ref with better CLI and improved api ca…

### DIFF
--- a/docs/developers.rst
+++ b/docs/developers.rst
@@ -45,19 +45,16 @@ For more details, see `benchmarking/README.md <https://github.com/RadioAstronomy
 Running a Reference Simulation with pytest-benchmark
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To run a single core regression test of the reference simulations, you need to specify a reference
-simulation with the ``refsim`` flag and use ``benchmark-only``. Additionally, you need to use
-mpiexec to run pytest as follows:
+To run a single core regression test of the reference simulations, you need to specify a reference simulation with the ``refsim`` flag and use ``benchmark-only``. Additionally, you need to use mpiexec to run pytest as follows:
 
     .. code-block:: python
 
         # use mpiexec to run pytest specifying one core
         > mpiexec -n 1 -np 1 pytest --refsim=1.1_uniform --benchmark-only
 
-Here "1.1_uniform" would be the specific reference simulation being tested. You can use the ``refsim``
-flag multiple times to parametrize multiple reference simulations: ``--refsim=refsim1 --refsim=refsim2``.
+Here "1.1_uniform" would be the specific reference simulation being tested. You can use the ``refsim`` flag multiple times to parametrize multiple reference simulations: ``--refsim=refsim1 --refsim=refsim2``. Multiple simulations can also be specified with ``--refsim={refsim1,refsim2,...}``.
 
-We run single core regression tests of the available reference simulations with pytest and pytest-benchmark via our github ci workflow on every push or pull request. We do so to ensure output and runtime consistency. As we only run the simulations with a single core, the benchmarking aspect of these tests is only relevant for linear operations and not a test of any parallelism.
+We run single core regression tests of the available reference simulations with pytest and pytest-benchmark via our github ci workflow on every pull request. We do so to ensure output and runtime consistency. As we only run the simulations with a single core, the benchmarking aspect of these tests is only relevant for linear operations and not a test of any parallelism. Historical simulation output is currently stored on the Brown Digital Repository.
 
 The available ``refsim`` values are:
 
@@ -68,3 +65,14 @@ The available ``refsim`` values are:
 * 1.2_gauss
 * 1.3_uniform
 * 1.3_gauss
+
+These values, and additional custom options defined for pytest such as ``--savesim``, can be seen under the custom options section of the output of ``pytest --help``.
+
+To merge a pull request that changes the output of the reference simulations, you should generate a new set of reference simulation outputs to upload to the Brown Digital Repository. The line to do this currently is:
+
+    .. code-block:: python
+
+        # use mpiexec to run pytest specifying one core
+        > mpiexec -n 1 -np 1 pytest --refsim={1.1_uniform,1.1_gauss,1.1_mwa,1.2_uniform,1.2_gauss,1.3_uniform,1.3_gauss} --benchmark-only --savesim
+
+This will run all the active reference simulations, and write the new and reference data out in a ``test_sim_output`` directory located in the current working directory. The ``new_data`` subdirectory should then be uploaded to the Brown Digital Repository to serve as the updated reference simulations. If you just want to run the reference simulations locally but not save anything, the ``--savesim`` flag can be dropped -- in this case it can be nice to use the ``-s`` flag to see all printed output.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,10 +58,25 @@ def pytest_addoption(parser):
         "--nompi", action="store_true", help="skip mpi-parallelized tests."
     )
     parser.addoption(
+        "--savesim",
+        action="store_true",
+        default=False,
+        help="saves reference simulation output to the current working directory",
+    )
+    parser.addoption(
         "--refsim",
         action="append",
         default=[],
-        help="list of refsim names to pass to test functions.",
+        help="specify an available reference simulation to pass to test functions",
+        choices=[
+            "1.1_uniform",
+            "1.1_gauss",
+            "1.1_mwa",
+            "1.2_uniform",
+            "1.2_gauss",
+            "1.3_uniform",
+            "1.3_gauss",
+        ],
     )
 
 
@@ -274,3 +289,8 @@ def apollo_loc():
 
         return MoonLocation(lat=0.6875, lon=24.433, height=0)
     return None
+
+
+@pytest.fixture(scope="session")
+def savesim(request):
+    return request.config.getoption("--savesim")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Updated conftest and test_run_ref for better CLI and improved Brown Digital Repository api call. These updates added a feature to save test simulation output locally via the pytest ``--savesim`` flag, to allow for easy generation and downloading of sets of reference simulations for a given pyuvsim branch. The ``--refsim`` flag was updated to list the available reference simulations. The pytest benchmarking documentation was updated in support of these changes, with an explicit line provided to run all reference simulations via pytest and save the BDR reference data and simulation output locally.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This change allows for much easier generation of new sets of reference simulations for upload to the Brown Digital Repository. The improved api call is also somewhat necessary as before the api calls scaled as the number of uploaded reference simulations of a given name which was possibly causing workflow failures. Other minor fixes are included, including updating the reference simulation equality check to have a tolerance of (1e-7, 0), matching what is ran locally in test_run_ref.

<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [x] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I have updated the documentation to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [x] All new and existing tests pass.
- [x] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [ ] I have checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/main/CHANGELOG.md).

Documentation change checklist:
- [x] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)