### PR TITLE
Updated initialize_catalog_from_params to check pyuvsim cache as fall…

### DIFF
--- a/src/pyuvsim/simsetup.py
+++ b/src/pyuvsim/simsetup.py
@@ -34,6 +34,7 @@ from astropy.coordinates import (
     SkyCoord,
 )
 from astropy.time import Time
+from astropy.utils.data import cache_contents, is_url_in_cache
 from packaging import version  # packaging is installed with setuptools
 from pyradiosky import SkyModel
 from pyuvdata import (
@@ -991,8 +992,14 @@ def initialize_catalog_from_params(
         mock_keyvals = [str(key) + str(val) for key, val in mock_keywords.items()]
         source_list_name = "mock_" + "_".join(mock_keyvals)
     elif isinstance(catalog, str):
+        # if catalog file is not found, first check relative to config_path,
+        # then check astropy cache treating catalog input as url
         if not os.path.isfile(catalog):
-            catalog = os.path.join(param_dict["config_path"], catalog)
+            relative_path = os.path.join(param_dict["config_path"], catalog)
+            if os.path.isfile(relative_path):
+                catalog = relative_path
+            elif is_url_in_cache(catalog, pkgname="pyuvsim"):
+                catalog = cache_contents("pyuvsim")[catalog]
 
         allowed_read_params = [
             "spectral_type",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In initialize_catalog_from_params, if neither the catalog name nor the relative path constructed from the config_path exist, checks the pyuvsim cache using astropy as a final fallback treating the catalog as the cached url.

Where this functionality is immediately important is in the reference simulations of pyuvsim. The current approach to running the new reference simulations is to install the larger data files to the pyuvsim cache specified by astropy using download_file. There is currently no method to appropriately target cached catalog files besides manually editing the yaml file to insert the absolute path to the file, a problem that this pr solves.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change

## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the documentation to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [ ] I have checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/main/CHANGELOG.md).