### PR TITLE
fix CI bug and warnings about conda defaults channel

### DIFF
--- a/.github/workflows/compare-post-benchmark.yaml
+++ b/.github/workflows/compare-post-benchmark.yaml
@@ -52,6 +52,7 @@ jobs:
           environment-file: ci/${{ env.ENV_NAME }}.yaml
           activate-environment: ${{ env.ENV_NAME }}
           run-post: false
+          conda-remove-defaults: "true"
 
       - name: Conda Info
         run: |

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
   pull_request:
-    branch: main
+    branches: main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -33,6 +33,7 @@ jobs:
           python-version: ${{ env.PYTHON }}
           environment-file: ci/${{ env.ENV_NAME }}.yaml
           activate-environment: ${{ env.ENV_NAME }}
+          conda-remove-defaults: "true"
 
       - name: Conda Info
         run: |

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -45,6 +45,7 @@ jobs:
           python-version: ${{ env.PYTHON }}
           environment-file: ci/${{ env.ENV_NAME }}.yaml
           activate-environment: ${{ env.ENV_NAME }}
+          conda-remove-defaults: "true"
 
       - name: Conda Info
         run: |
@@ -143,6 +144,7 @@ jobs:
           python-version: ${{ env.PYTHON }}
           environment-file: ci/${{ env.ENV_NAME }}.yaml
           activate-environment: ${{ env.ENV_NAME }}
+          conda-remove-defaults: "true"
 
       - name: Conda Info
         run: |
@@ -191,6 +193,7 @@ jobs:
           python-version: ${{ env.PYTHON }}
           environment-file: ci/${{ env.ENV_NAME }}.yaml
           activate-environment: ${{ env.ENV_NAME }}
+          conda-remove-defaults: "true"
 
       - name: Conda Info
         run: |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Fix a misspelled GitHub action option ("branch" -> "branches")
- Ensure that conda "defaults" channel is not used. Note that even with this fix there are still some warnings about this but they seem to be unavoidable and the number of warnings is now reduced

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [x] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
