### PR TITLE
Fix write ms to set force_phase so it will actually write out our sims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ feed_angle, mount_type) which will be released in pyuvdata 3.2
 - Only import lunarsky if needed.
 
 ### Fixed
+- A bug where measurement sets could not be written out because they were not
+phased.
 - A bug where antennas that did not have visibilities associated with them were
 being initialized in `run_uvdata_uvsim`.
 - A bug in the way the time and frequency arrays were set up from the obsparam

--- a/ci/pyuvsim_tests_mpich.yaml
+++ b/ci/pyuvsim_tests_mpich.yaml
@@ -11,7 +11,7 @@ dependencies:
   - numpy>=1.23
   - pip
   - psutil
-  - python-casacore>=3.5.2<3.7.1
+  - python-casacore>=3.5.2,<3.7.1
   - pytest
   - pytest-cov>=5.0
   - pytest-xdist

--- a/ci/pyuvsim_tests_mpich.yaml
+++ b/ci/pyuvsim_tests_mpich.yaml
@@ -11,7 +11,7 @@ dependencies:
   - numpy>=1.23
   - pip
   - psutil
-  - python-casacore>=3.5.2
+  - python-casacore>=3.5.2<3.7.1
   - pytest
   - pytest-cov>=5.0
   - pytest-xdist

--- a/ci/pyuvsim_tests_openmpi.yaml
+++ b/ci/pyuvsim_tests_openmpi.yaml
@@ -11,7 +11,7 @@ dependencies:
   - openmpi
   - pip
   - psutil
-  - python-casacore>=3.5.2
+  - python-casacore>=3.5.2<3.7.1
   - pytest
   - pytest-cov>=5.0
   - pytest-xdist

--- a/ci/pyuvsim_tests_openmpi.yaml
+++ b/ci/pyuvsim_tests_openmpi.yaml
@@ -11,7 +11,7 @@ dependencies:
   - openmpi
   - pip
   - psutil
-  - python-casacore>=3.5.2<3.7.1
+  - python-casacore>=3.5.2,<3.7.1
   - pytest
   - pytest-cov>=5.0
   - pytest-xdist

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pre-commit
   - psutil
   - pypandoc
-  - python-casacore>=3.5.2<3.7.1
+  - python-casacore>=3.5.2,<3.7.1
   - pytest
   - pytest-cov>=5.0.0
   - pytest-xdist

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pre-commit
   - psutil
   - pypandoc
-  - python-casacore>=3.5.2
+  - python-casacore>=3.5.2<3.7.1
   - pytest
   - pytest-cov>=5.0.0
   - pytest-xdist

--- a/src/pyuvsim/utils.py
+++ b/src/pyuvsim/utils.py
@@ -267,7 +267,12 @@ def write_uvdata(
                     "casacore is not installed but is required for measurement set "
                     "functionality"
                 ) from error
-            uv_obj.write_ms(outfile_name, clobber=not noclobber, fix_autos=fix_autos)
+            uv_obj.write_ms(
+                outfile_name,
+                force_phase=True,
+                clobber=not noclobber,
+                fix_autos=fix_autos,
+            )
         else:
             raise ValueError(
                 "Invalid output format. Options are 'uvfits', 'uvh5', 'miriad' or 'ms'."

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -46,6 +46,8 @@ def test_profiler(tmpdir):
     lstats = time_profiler.get_stats()
     assert len(lstats.timings) != 0
     func_names = [k[2] for k in lstats.timings]
+    # just get the function names (not objects)
+    func_names = [name.split(".")[-1] for name in func_names]
     assert unique(func_names).tolist() == sorted(
         pyuvsim.profiling.default_profile_funcs
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -118,6 +118,8 @@ def test_write_uvdata(save_format, tmpdir):
         pytest.skip("miriad is not supported on Windows")
 
     uv = UVData.from_file(triangle_uvfits_file)
+    # unphase so it is similar to what comes out of run_uvsim
+    uv.unproject_phase()
 
     ofname = str(tmpdir.join("test_file"))
     filing_dict = {"outfile_name": ofname}
@@ -163,6 +165,8 @@ def test_write_uvdata_clobber(save_format, tmpdir):
         pytest.importorskip("casacore")
 
     uv = UVData.from_file(triangle_uvfits_file)
+    # unphase so it is similar to what comes out of run_uvsim
+    uv.unproject_phase()
 
     uv.set_lsts_from_time_array()
     filing_dict = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set `force_phase` to True when writing out measurement sets.

Also had to fix a few things related to new dependency releases:
- pin python-casacore in conda yamls because of a build problem, see #579 
- fix parsing of line profiler functions in profiler test

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
fixes #575 

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [ ] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass.
- [x] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [x] I have checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR.
- [x] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/main/CHANGELOG.md).
