### PR TITLE
WIP - Swapped convert to magick due to deprecation warning making mac tests fail

### DIFF
--- a/ci/min_versions.yaml
+++ b/ci/min_versions.yaml
@@ -6,7 +6,7 @@ dependencies:
   - astropy-healpix==1.0.2
   - coverage
   - line_profiler
-  - matplotlib==3.6.*
+  - matplotlib==3.10.7
   - mpi4py==3.1.3
   - numpy==1.23.*
   - pip

--- a/ci/pyuvsim_tests_mpich.yaml
+++ b/ci/pyuvsim_tests_mpich.yaml
@@ -22,6 +22,7 @@ dependencies:
   - scipy>=1.9
   - setuptools_scm>=8.1
   - ghostscript
+  - urw-base35-fonts
   - pip:
     - pyradiosky>=1.1.0
     - mpi-pytest>=2025.7.0

--- a/ci/pyuvsim_tests_mpich.yaml
+++ b/ci/pyuvsim_tests_mpich.yaml
@@ -6,7 +6,7 @@ dependencies:
   - astropy-healpix>=1.0.2
   - coverage
   - line_profiler
-  - matplotlib>=3.6.*
+  - matplotlib>=3.10.7
   - mpich
   - mpi4py>=3.1.3
   - numpy>=1.23
@@ -21,6 +21,7 @@ dependencies:
   - pyyaml>=5.4.1
   - scipy>=1.9
   - setuptools_scm>=8.1
+  - ghostscript
   - pip:
     - pyradiosky>=1.1.0
     - mpi-pytest>=2025.7.0

--- a/ci/pyuvsim_tests_openmpi.yaml
+++ b/ci/pyuvsim_tests_openmpi.yaml
@@ -6,7 +6,7 @@ dependencies:
   - astropy-healpix>=1.0.2
   - coverage
   - line_profiler
-  - matplotlib>=3.6.*
+  - matplotlib>=3.10.7
   - mpi4py>=3.1.3
   - numpy>=1.23
   - openmpi
@@ -21,6 +21,7 @@ dependencies:
   - pyyaml>=5.4.1
   - scipy>=1.9
   - setuptools_scm>=8.1
+  - ghostscript
   - pip:
     - pyradiosky>=1.1.0
     - mpi-pytest>=2025.7.0

--- a/ci/pyuvsim_tests_openmpi.yaml
+++ b/ci/pyuvsim_tests_openmpi.yaml
@@ -22,6 +22,7 @@ dependencies:
   - scipy>=1.9
   - setuptools_scm>=8.1
   - ghostscript
+  - urw-base35-fonts
   - pip:
     - pyradiosky>=1.1.0
     - mpi-pytest>=2025.7.0

--- a/ci/pyuvsim_tests_windows.yaml
+++ b/ci/pyuvsim_tests_windows.yaml
@@ -7,7 +7,7 @@ dependencies:
   - coverage
   - line_profiler
   - freetype<2.14
-  - matplotlib>=3.6.*
+  - matplotlib>=3.10.7
   - mpi4py>=3.1.3
   - numpy>=1.23
   - pip
@@ -21,6 +21,7 @@ dependencies:
   - scipy>=1.9
   - setuptools_scm>=8.1
   - msmpi
+  - ghostscript
   - pip:
     - pyradiosky>=1.1.0
     - mpi-pytest>=2025.7.0

--- a/ci/pyuvsim_tests_windows.yaml
+++ b/ci/pyuvsim_tests_windows.yaml
@@ -6,7 +6,7 @@ dependencies:
   - astropy-healpix>=1.0.2
   - coverage
   - line_profiler
-  - freetype<2.14
+  - freetype<=2.14.1
   - matplotlib>=3.10.7
   - mpi4py>=3.1.3
   - numpy>=1.23
@@ -21,7 +21,6 @@ dependencies:
   - scipy>=1.9
   - setuptools_scm>=8.1
   - msmpi
-  - ghostscript
   - pip:
     - pyradiosky>=1.1.0
     - mpi-pytest>=2025.7.0

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - astropy-healpix>=1.0.2
   - astroquery>=0.4.4
   - line_profiler
-  - matplotlib>=3.6.*
+  - matplotlib>=3.10.7
   - mpi4py>=3.1.3
   - numpy>=1.23
   - pip
@@ -25,6 +25,7 @@ dependencies:
   - scipy>=1.9
   - setuptools_scm>=8.1
   - sphinx
+  - ghostscript
   - pip:
     - pyradiosky>=1.1.0
     - mpi-pytest>=2025.7.0

--- a/src/pyuvsim/cli.py
+++ b/src/pyuvsim/cli.py
@@ -302,7 +302,7 @@ def create_text_catalog(
         ) from ie
 
     try:
-        subprocess.check_output(["convert", "--version"])  # nosec
+        subprocess.check_output(["magick", "--version"])  # nosec
     except (FileNotFoundError, subprocess.CalledProcessError) as err:
         raise RuntimeError(
             "ImageMagick must installed to create text catalogs"
@@ -317,7 +317,7 @@ def create_text_catalog(
     dpi = int(np.ceil(char_pix_height / emsize))
     # dpi = height of a letter in pixels/hight of letter in inches
     im_cmd = [
-        "convert",
+        "magick",
         "-background",
         "black",
         "-fill",
@@ -330,10 +330,10 @@ def create_text_catalog(
         "PixelsPerInch",
         "-density",
         str(dpi),
-        "-trim",
-        "+repage",
         "-antialias",
         "label:" + text.upper(),
+        "-trim",
+        "+repage",
         f"{imgfname}",
     ]
     if verbose > 1:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,7 @@ from pyuvsim import cli
 from pyuvsim.data import DATA_PATH as SIM_DATA_PATH
 
 try:
-    subprocess.check_output(["convert", "--version"])  # nosec
+    subprocess.check_output(["magick", "--version"])  # nosec
     img_mgk_installed = True
 except (FileNotFoundError, subprocess.CalledProcessError):
     img_mgk_installed = False
@@ -105,7 +105,7 @@ def test_text_to_catalog_basic(verbosity, plot, use_old, goto_tempdir, capsys):
             assert "saved catalog file to" in output
         else:
             assert output.startswith(
-                "['convert', '-background', 'black', '-fill', 'white'"
+                "['magick', '-background', 'black', '-fill', 'white'"
             )
             assert "generating image file" in output
             assert "saved catalog file to" in output


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

On recent versions of imagemagick running `convert` prints a deprecation warning to switch to using `magick`, which makes the mac tests fail.

## Description
<!--- Describe your changes in detail -->

 `convert` has been swapped to `magick`. Additionally, `magick` seems to care more about the argument order -- to get the old `convert` line to run with `magick`, `-trim` and `+repage` needed to have their positions changes.

Two additional issues occurred during testing: the font used for the image rendering was not found, and an additional deprecation warning was caught due to matplotlib <= 3.10.6 using `enablePackrat()` instead of `enable_Packrat()`. To resolve these issues, the minimum matplotlib version has been bumped to 3.10.7, and ghostscript has been added to the conda yamls to include the font on all operating systems -- this did not seem to resolve the font finding issue. I'm not sure what changed to make the font no longer exist / findable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Bug fix checklist:
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [ ] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [ ] I have checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/main/CHANGELOG.md).

New feature checklist:
- [ ] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the documentation to highlight my new feature (if appropriate).
- [ ] I have added tests to cover my new feature.
- [ ] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [ ] I have checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/main/CHANGELOG.md).

Breaking change checklist:
- [ ] I have updated the docstrings associated with my change using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the documentation to reflect my changes (if appropriate).
- [ ] My change includes backwards compatibility and deprecation warnings (if possible).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests pass.
- [ ] I have checked that I reproduce the reference simulations or if there are differences they are explained below (if appropriate). If there are changes that are correct, I will update the reference simulation files after this PR is merged.
- [ ] I have checked (e.g., using the benchmarking tools) that this change does not significantly increase typical runtimes. If it does, I have included a justification in the comments on this PR.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/main/CHANGELOG.md).

Reference simulation update or replacement:
- [ ] If this is a new reference simulation or if the settings files have changed, I have added all the relevant files to the reference_simulations folder.
- [ ] If this is a new reference simulation I have fully documented it in a memo in docs and updated any other docs as appropriate.
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/main/CHANGELOG.md).

Documentation change checklist:
- [ ] Any updated docstrings use the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. (you may need help to get this branch to build on RTD, just ask!)

Version change checklist:
- [ ] I have updated the [CHANGELOG](https://github.com/RadioAstronomySoftwareGroup/pyuvsim/blob/main/CHANGELOG.md) to put all the unreleased changes under the new version (leaving the unreleased section empty).
- [ ] I have run the appropriate tests for this level of version change (described in the readme under versioning).

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
