### PR TITLE
remove spice dependency from tests for updated lunarsky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+- Require lunarsky>1.0 to drop spiceypy requirement
+
+### Removed
+- Spiceypy error catching in tests
+
 ## [1.4.2] - 2025-10-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Optional:
 
 * astropy-healpix>=1.0.2 (for using healpix based sky catalogs or beams)
 * mpi4py>=3.1.3 (for actually running simulations)
-* lunarsky>=0.2.5 (for simulating telescopes on the moon)
+* lunarsky>=1.0 (for simulating telescopes on the moon)
 * python-casacore>=3.5.2 (for writing CASA measurement sets, not available on Windows)
 * matplotlib>=3.6 (for plotting functions)
 

--- a/ci/min_versions.yaml
+++ b/ci/min_versions.yaml
@@ -23,5 +23,5 @@ dependencies:
   - pip:
     - pyradiosky==1.1.0
     - mpi-pytest==2025.7.0
-    - lunarsky==0.2.5
+    - lunarsky==1.0.1.post2
     - git+https://github.com/aelanman/analytic_diffuse

--- a/ci/pyuvsim_tests_mpich.yaml
+++ b/ci/pyuvsim_tests_mpich.yaml
@@ -24,5 +24,5 @@ dependencies:
   - pip:
     - pyradiosky>=1.1.0
     - mpi-pytest>=2025.7.0
-    - lunarsky>=0.2.5
+    - lunarsky>=1.0
     - git+https://github.com/aelanman/analytic_diffuse

--- a/ci/pyuvsim_tests_openmpi.yaml
+++ b/ci/pyuvsim_tests_openmpi.yaml
@@ -24,5 +24,5 @@ dependencies:
   - pip:
     - pyradiosky>=1.1.0
     - mpi-pytest>=2025.7.0
-    - lunarsky>=0.2.5
+    - lunarsky>=1.0
     - git+https://github.com/aelanman/analytic_diffuse

--- a/ci/pyuvsim_tests_refsim.yaml
+++ b/ci/pyuvsim_tests_refsim.yaml
@@ -24,6 +24,6 @@ dependencies:
     - pyradiosky>=1.1.0
     - pytest-benchmark
     - mpi-pytest>=2025.7.0
-    - lunarsky>=0.2.5
+    - lunarsky>=1.0
     - git+https://github.com/aelanman/analytic_diffuse
     - requests

--- a/environment.yml
+++ b/environment.yml
@@ -28,5 +28,5 @@ dependencies:
   - pip:
     - pyradiosky>=1.1.0
     - mpi-pytest>=2025.7.0
-    - lunarsky>=0.2.5
+    - lunarsky>=1.0
     - git+https://github.com/aelanman/analytic_diffuse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ classifiers = [
 [project.optional-dependencies]
 casa = ["python-casacore>=3.5.2"]
 healpix = ["astropy-healpix>=1.0.2"]
-moon = ["lunarsky>=0.2.5"]
+moon = ["lunarsky>=1.0"]
 plot = ["matplotlib>=3.6"]
 sim = ["mpi4py>=3.1.3", "psutil"]
 sim-test = ["pyuvsim[sim,test]", "mpi-pytest>=2025.7.0"]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -548,7 +548,6 @@ def test_pol_error():
 @pytest.mark.parametrize("selenoid", ["SPHERE", "GSFC", "GRAIL23", "CE-1-LAM-GEO"])
 def test_sim_on_moon(goto_tempdir, selenoid):
     pytest.importorskip("lunarsky")
-    from spiceypy.utils.exceptions import SpiceUNKNOWNFRAME
 
     param_filename = os.path.join(
         SIM_DATA_PATH, "test_config", "obsparam_tranquility_hex.yaml"
@@ -609,12 +608,9 @@ def test_sim_on_moon(goto_tempdir, selenoid):
         return_data=True,
     )
     # Run simulation.
-    try:
-        uv_out = pyuvsim.uvsim.run_uvdata_uvsim(
-            uv_obj, beam_list, beam_dict, catalog=sources, quiet=True
-        )
-    except SpiceUNKNOWNFRAME as err:
-        pytest.skip("SpiceUNKNOWNFRAME error: " + str(err))
+    uv_out = pyuvsim.uvsim.run_uvdata_uvsim(
+        uv_obj, beam_list, beam_dict, catalog=sources, quiet=True
+    )
 
     assert history_utils._check_history_version(uv_out.history, pyradiosky.__version__)
     assert history_utils._check_history_version(uv_out.history, pyuvdata.__version__)
@@ -640,7 +636,6 @@ def test_sim_on_moon(goto_tempdir, selenoid):
 def test_lunar_gauss(goto_tempdir, selenoid):
     pytest.importorskip("lunarsky")
     from lunarsky import MoonLocation
-    from spiceypy.utils.exceptions import SpiceUNKNOWNFRAME
 
     # Make a gaussian source that passes through zenith
     # Confirm that simulated visibilities match expectation.
@@ -680,10 +675,7 @@ def test_lunar_gauss(goto_tempdir, selenoid):
 
     params["filing"]["outdir"] = str(tmpdir)
 
-    try:
-        uv_out = pyuvsim.run_uvsim(params, return_uv=True, quiet=True)
-    except SpiceUNKNOWNFRAME as err:
-        pytest.skip("SpiceUNKNOWNFRAME error: " + str(err))
+    uv_out = pyuvsim.run_uvsim(params, return_uv=True, quiet=True)
 
     assert uv_out.telescope.location.ellipsoid == selenoid
 


### PR DESCRIPTION
## Description

The latest version of lunarsky drops the dependency on spiceypy. As a result, the try blocks that catch SPICEUnknownFrameErrors in unit tests can be removed. This also bumps the minimum version of lunarsky.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This cleans up code that will no longer be needed.

Build or continuous integration change checklist:
- [x] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [x] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
