### PR TITLE
Add zizmor to pre-commit and configure dependabot action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 14

--- a/.github/workflows/compare-post-benchmark.yaml
+++ b/.github/workflows/compare-post-benchmark.yaml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   benchmark:
     # Job that clones pyuvsim@main, sets up a conda environment with the necessary dependencies,
@@ -41,10 +43,12 @@ jobs:
         # Adding -l {0} helps ensure conda can be found properly.
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           miniforge-version: latest
           python-version: ${{ env.PYTHON }}
@@ -78,7 +82,7 @@ jobs:
       # upload the benchmark output as an artifact with name key corresponding to the current
       # workflow run and attempt only store artifacts for 1 day
       - name: Upload result artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.id }}
           path: artifacts/
@@ -108,17 +112,19 @@ jobs:
 
     steps:
       # Checkout repo for the github-action-benchmark action
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # setup python
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.x'
 
       # only downloads artifacts from current workflow and run attempt via the pattern matching
       # loads the saved benchmark artifacts from running the benchmark matrix into artifacts/
       - name: Download result artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: ${{ github.run_id }}-${{ github.run_attempt }}-*
@@ -135,7 +141,7 @@ jobs:
       # then takes the benchmark timing info from n-1 files and adds it to the first file.
       # With this approach, benchmark comparison output is only a single table, and we only
       # have one comment on alert in the workflow.
-      - uses: jannekem/run-python-script-action@v1
+      - uses: jannekem/run-python-script-action@9d8e2e0878d575fb6073277f38ce3f10ebf4f059 # v1.8
         with:
           script: |
             import os
@@ -166,8 +172,8 @@ jobs:
       # Print github event_name and ref_name and the boolean check for whether gh-pages should be updated
       - name: Print Event, Ref, and Upload Boolean
         run: |
-          echo "Event Name: ${{ github.event_name }}"
-          echo "Ref Name: ${{ github.ref_name }}"
+          echo "Event Name: ${GITHUB_EVENT_NAME}"
+          echo "Ref Name: ${GITHUB_REF_NAME}"
           echo "Update gh-pages: ${{ github.event_name == 'push' && github.ref_name == 'main' }}"
 
       # Compares the data from the specified "output-file-path" and compares
@@ -178,7 +184,7 @@ jobs:
       # https://github.com/benchmark-action/github-action-benchmark?tab=readme-ov-file#caveats
       # This only updates gh-pages if a push to main occurs
       - name: Compare benchmarks
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:
           # What benchmark tool the output.txt came from
           tool: 'pytest'

--- a/.github/workflows/externaltests.yaml
+++ b/.github/workflows/externaltests.yaml
@@ -5,6 +5,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   pyuvsim:
     name: herasim
@@ -17,14 +19,15 @@ jobs:
       PYTHON: "3.12"
 
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-         fetch-depth: 0
+          fetch-depth: 0
+          persist-credentials: false
 
-      - uses: mpi4py/setup-mpi@v1
+      - uses: mpi4py/setup-mpi@f200dce75b64188be849b46657dcf86c721937b2 # v1.4.3
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON }}
 
@@ -56,7 +59,7 @@ jobs:
         run: |
           pip list
           PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
+          if [[ $PYVER != $PYTHON ]]; then
             exit 1;
           fi
 

--- a/.github/workflows/publish-to-test-pypi.yaml
+++ b/.github/workflows/publish-to-test-pypi.yaml
@@ -14,6 +14,9 @@ jobs:
   build-n-publish:
     name: Build and publish to PyPI and TestPyPI
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for Trusted Publishing
+      id-token: write
     defaults:
       run:
         # Adding -l {0} helps ensure conda can be found properly.
@@ -22,12 +25,13 @@ jobs:
       ENV_NAME: publish
       PYTHON: "3.12"
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           miniforge-version: latest
           python-version: ${{ env.PYTHON }}
@@ -40,7 +44,7 @@ jobs:
           conda info -a
           conda list
           PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
+          if [[ $PYVER != $PYTHON ]]; then
             exit 1;
           fi
 
@@ -60,13 +64,10 @@ jobs:
 
       - name: Publish to Test PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
-          password: ${{ secrets.test_pypi_password }}
           repository_url: https://test.pypi.org/legacy/
 
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.pypi_password }}
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -5,6 +5,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   tests:
     env:
@@ -34,9 +36,10 @@ jobs:
             python-version: "3.13"
             os: windows-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Ghostscript on Mac
         if: matrix.os == 'macos-latest'
@@ -45,12 +48,12 @@ jobs:
 
       - name: Install ImageMagick
         if: matrix.os != 'windows-latest'
-        uses: mfinelli/setup-imagemagick@v6
+        uses: mfinelli/setup-imagemagick@e5a049b136cb833d5c0474b38d166f0bdb0e4497 # v7.0.1
         with:
           cache: False
 
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           miniforge-version: latest
           python-version: ${{ env.PYTHON }}
@@ -63,7 +66,7 @@ jobs:
           conda info -a
           conda list
           PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
+          if [[ $PYVER != $PYTHON ]]; then
             exit 1;
           fi
 
@@ -90,7 +93,7 @@ jobs:
           cat coverage.xml
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
@@ -106,12 +109,13 @@ jobs:
     name: Min Deps Testing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ env.PYTHON }}
 
@@ -125,7 +129,7 @@ jobs:
         run: |
           pip list
           PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
+          if [[ $PYVER != $PYTHON ]]; then
             exit 1;
           fi
 
@@ -138,7 +142,7 @@ jobs:
           ls
           cat coverage.xml
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
@@ -155,11 +159,13 @@ jobs:
         shell: bash -l {0}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
+
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           miniforge-version: latest
           python-version: ${{ env.PYTHON }}
@@ -172,7 +178,7 @@ jobs:
           conda info -a
           conda list
           PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
+          if [[ $PYVER != $PYTHON ]]; then
             exit 1;
           fi
 
@@ -189,7 +195,7 @@ jobs:
           ls
           cat coverage.xml
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
@@ -208,12 +214,13 @@ jobs:
         # Adding -l {0} helps ensure conda can be found properly.
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           miniforge-version: latest
           python-version: ${{ env.PYTHON }}
@@ -226,7 +233,7 @@ jobs:
           conda info -a
           conda list
           PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
+          if [[ $PYVER != $PYTHON ]]; then
             exit 1;
           fi
 
@@ -244,7 +251,7 @@ jobs:
           cat coverage.xml
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
@@ -263,12 +270,13 @@ jobs:
         # Adding -l {0} helps ensure conda can be found properly.
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Miniforge
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           miniforge-version: latest
           python-version: ${{ env.PYTHON }}
@@ -281,7 +289,7 @@ jobs:
           conda info -a
           conda list
           PYVER=`python -c "import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
-          if [[ $PYVER != ${{ env.PYTHON }} ]]; then
+          if [[ $PYVER != $PYTHON ]]; then
             exit 1;
           fi
 
@@ -299,7 +307,7 @@ jobs:
           cat coverage.xml
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required

--- a/.github/workflows/testsuite.yaml
+++ b/.github/workflows/testsuite.yaml
@@ -93,7 +93,7 @@ jobs:
           cat coverage.xml
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
@@ -142,11 +142,12 @@ jobs:
           ls
           cat coverage.xml
 
-      - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
           files: ./coverage.xml #optional
+          fail_ci_if_error: true
 
   min_versions:
     env:
@@ -195,7 +196,7 @@ jobs:
           ls
           cat coverage.xml
 
-      - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
@@ -251,7 +252,7 @@ jobs:
           cat coverage.xml
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required
@@ -307,7 +308,7 @@ jobs:
           cat coverage.xml
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: success()
         with:
           token: ${{secrets.CODECOV_TOKEN}} #required

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,8 @@ repos:
     hooks:
       - id: bandit
         args: [--skip, "B101", --recursive, pyuvsim]
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.25.2
+    hooks:
+    - id: zizmor


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added zizmor to pre-commit to improve security of GitHub actions.

One of the things they push is using commit hashes for GitHub actions you use. Unfortunately that can lock you into old versions, so I also added a dependabot config to help keep actions up to date.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Reference simulation update or replacement
- [ ] Documentation change (documentation changes only)
- [ ] Version change
- [x] Build or continuous integration change


## Checklist:
<!--- You may remove the checklists that don't apply to your change type(s) or just leave them empty -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
For all pull requests:
- [x] I have read the [contribution guide](CONTRIBUTING.md).
- [x] My code follows the code style of this project.

Build or continuous integration change checklist:
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the readme to reflect this.
- [ ] If this is a new CI setup, I have added the associated badge to the readme and to references/make_index.py (if appropriate).
